### PR TITLE
optimize root hash calculation with adaptive parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ The service is configured via environment variables:
 |----------|-------------|---------|
 | `BATCH_LIMIT` | Maximum number of commitments to process per batch | `1000` |
 | `ROUND_DURATION` | Duration between block creation rounds | `1s` |
+| `SMT_MAX_GOROUTINES` | Maximum concurrent goroutines for SMT hash calculations | CPU-based (2×cores, min 8, max 512) |
+
+**SMT Goroutine Configuration:**
+- **Not set** or **negative values**: Uses CPU-based defaults (2× CPU cores, minimum 8, maximum 512)
+- **0**: Sequential processing (no parallel goroutines)  
+- **Positive values**: Uses specified number of goroutines for parallel processing
 
 ## API Endpoints
 

--- a/cmd/aggregator/main.go
+++ b/cmd/aggregator/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/unicitynetwork/aggregator-go/internal/gateway"
 	"github.com/unicitynetwork/aggregator-go/internal/logger"
 	"github.com/unicitynetwork/aggregator-go/internal/service"
+	"github.com/unicitynetwork/aggregator-go/internal/smt"
 	"github.com/unicitynetwork/aggregator-go/internal/storage/mongodb"
 )
 
@@ -22,6 +23,9 @@ func main() {
 		fmt.Printf("Failed to load configuration: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Configure SMT goroutine limits from configuration
+	smt.SetMaxConcurrentGoroutines(cfg.Processing.SMTMaxGoroutines)
 
 	// Initialize logger
 	baseLogger, err := logger.New(
@@ -45,7 +49,7 @@ func main() {
 		}
 		asyncLogger = logger.NewAsyncLogger(baseLogger, bufferSize)
 		log = asyncLogger.Logger
-		log.WithComponent("main").Info("Async logging enabled", 
+		log.WithComponent("main").Info("Async logging enabled",
 			"bufferSize", bufferSize)
 	} else {
 		log = baseLogger
@@ -126,7 +130,7 @@ func main() {
 	}
 
 	log.WithComponent("main").Info("Aggregator shut down successfully")
-	
+
 	// Stop async logger if enabled
 	if asyncLogger != nil {
 		asyncLogger.Stop()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       # Server Configuration
       PORT: "3000"
       HOST: "0.0.0.0"
+      SMT_MAX_GOROUTINES: "0"
       CONCURRENCY_LIMIT: "1000"
       ENABLE_DOCS: "true"
       ENABLE_CORS: "true"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,18 +63,19 @@ type HAConfig struct {
 
 // LoggingConfig holds logging configuration
 type LoggingConfig struct {
-	Level            string `mapstructure:"level"`
-	Format           string `mapstructure:"format"`
-	Output           string `mapstructure:"output"`
-	EnableJSON       bool   `mapstructure:"enable_json"`
-	EnableAsync      bool   `mapstructure:"enable_async"`
-	AsyncBufferSize  int    `mapstructure:"async_buffer_size"`
+	Level           string `mapstructure:"level"`
+	Format          string `mapstructure:"format"`
+	Output          string `mapstructure:"output"`
+	EnableJSON      bool   `mapstructure:"enable_json"`
+	EnableAsync     bool   `mapstructure:"enable_async"`
+	AsyncBufferSize int    `mapstructure:"async_buffer_size"`
 }
 
 // ProcessingConfig holds batch processing configuration
 type ProcessingConfig struct {
-	BatchLimit    int           `mapstructure:"batch_limit"`
-	RoundDuration time.Duration `mapstructure:"round_duration"`
+	BatchLimit       int           `mapstructure:"batch_limit"`
+	RoundDuration    time.Duration `mapstructure:"round_duration"`
+	SMTMaxGoroutines int           `mapstructure:"smt_max_goroutines"`
 }
 
 type BFTConfig struct {
@@ -132,8 +133,9 @@ func Load() (*Config, error) {
 			AsyncBufferSize: getEnvIntOrDefault("LOG_ASYNC_BUFFER_SIZE", 10000),
 		},
 		Processing: ProcessingConfig{
-			BatchLimit:    getEnvIntOrDefault("BATCH_LIMIT", 1000),
-			RoundDuration: getEnvDurationOrDefault("ROUND_DURATION", "1s"),
+			BatchLimit:       getEnvIntOrDefault("BATCH_LIMIT", 1000),
+			RoundDuration:    getEnvDurationOrDefault("ROUND_DURATION", "1s"),
+			SMTMaxGoroutines: getEnvIntOrDefault("SMT_MAX_GOROUTINES", -1), // -1 means, CPU-based (2×cores, min 8, max 512)
 		},
 	}
 	config.BFT = BFTConfig{

--- a/internal/round/round_manager.go
+++ b/internal/round/round_manager.go
@@ -77,6 +77,9 @@ type RoundManager struct {
 
 // NewRoundManager creates a new round manager
 func NewRoundManager(cfg *config.Config, logger *logger.Logger, storage interfaces.Storage) (*RoundManager, error) {
+	// Configure SMT goroutine limits based on config
+	smt.SetMaxConcurrentGoroutines(cfg.Processing.SMTMaxGoroutines)
+
 	// Initialize SMT with thread-safe wrapper
 	smtInstance := smt.NewSparseMerkleTree(api.SHA256)
 	threadSafeSMT := NewThreadSafeSMT(smtInstance)


### PR DESCRIPTION
Root hash calcualtion performance was evaluated by utilizing BenchmarkSMTRootHashOnly test. Additionally, hash caching was disabled in code to have full tree hash calcualtion on every test run.

Root hash calculation performance with sequential approach:
```
goos: linux
goarch: amd64
pkg: github.com/unicitynetwork/aggregator-go/internal/smt
cpu: 12th Gen Intel(R) Core(TM) i7-1255U
BenchmarkSMTRootHashOnly/HashOnly_1k-12                     1494            729284 ns/op          614990 B/op      14994 allocs/op
BenchmarkSMTRootHashOnly/HashOnly_5k-12                      298           3896364 ns/op         3071852 B/op      74996 allocs/op
BenchmarkSMTRootHashOnly/HashOnly_10k-12                     152           7791941 ns/op         6151860 B/op     149996 allocs/op
BenchmarkSMTRootHashOnly/HashOnly_100k-12                     12          86507463 ns/op        61591853 B/op    1499996 allocs/op
PASS
ok      github.com/unicitynetwork/aggregator-go/internal/smt    8.171s
```

Root hash calculation performance using parallel approach:
```
goos: linux
goarch: amd64
pkg: github.com/unicitynetwork/aggregator-go/internal/smt
cpu: 12th Gen Intel(R) Core(TM) i7-1255U
BenchmarkSMTRootHashOnly/HashOnly_1k-12                     2454            463138 ns/op          687334 B/op      17996 allocs/op
BenchmarkSMTRootHashOnly/HashOnly_5k-12                      489           2377031 ns/op         3434489 B/op      90021 allocs/op
BenchmarkSMTRootHashOnly/HashOnly_10k-12                     250           4785997 ns/op         6879210 B/op     180070 allocs/op
BenchmarkSMTRootHashOnly/HashOnly_100k-12                     19          69916767 ns/op        68950190 B/op    1801643 allocs/op
PASS
ok      github.com/unicitynetwork/aggregator-go/internal/smt    7.826s
```