### PR TITLE
Hashing framework

### DIFF
--- a/internal/smt/smt.go
+++ b/internal/smt/smt.go
@@ -18,7 +18,7 @@ var (
 type (
 	// SparseMerkleTree implements a sparse merkle tree compatible with Unicity SDK
 	SparseMerkleTree struct {
-		algorithm  api.HashAlgorithm
+		hasher     *api.DataHasher
 		root       *RootNode
 		isSnapshot bool              // true if this is a snapshot, false if original tree
 		original   *SparseMerkleTree // reference to original tree (nil for original)
@@ -33,7 +33,7 @@ type (
 // NewSparseMerkleTree creates a new sparse merkle tree
 func NewSparseMerkleTree(algorithm api.HashAlgorithm) *SparseMerkleTree {
 	return &SparseMerkleTree{
-		algorithm:  algorithm,
+		hasher:     api.NewDataHasher(algorithm),
 		root:       newRootNode(nil, nil),
 		isSnapshot: false,
 		original:   nil,
@@ -44,7 +44,7 @@ func NewSparseMerkleTree(algorithm api.HashAlgorithm) *SparseMerkleTree {
 // The snapshot shares nodes with the original tree (copy-on-write)
 func (smt *SparseMerkleTree) CreateSnapshot() *SmtSnapshot {
 	snapshot := &SparseMerkleTree{
-		algorithm:  smt.algorithm,
+		hasher:     api.NewDataHasher(smt.hasher.GetAlgorithm()),
 		root:       smt.root, // Share the root initially
 		isSnapshot: true,
 		original:   smt,
@@ -121,7 +121,7 @@ type RootNode struct {
 
 // Branch interface for tree nodes (matches TypeScript Branch interface)
 type Branch interface {
-	calculateHash(algo api.HashAlgorithm) *api.DataHash
+	calculateHash(hasher *api.DataHasher) *api.DataHash
 	getPath() *big.Int
 	isLeaf() bool
 }
@@ -152,26 +152,23 @@ func newRootNode(left, right Branch) *RootNode {
 }
 
 // CalculateHash calculates root hash (matches TypeScript logic)
-func (r *RootNode) calculateHash(algo api.HashAlgorithm) *api.DataHash {
+func (r *RootNode) calculateHash(hasher *api.DataHasher) *api.DataHash {
 	var leftHash, rightHash []byte
 
 	if r.Left != nil {
-		leftHash = r.Left.calculateHash(algo).Data
+		leftHash = r.Left.calculateHash(hasher).RawHash
 	} else {
 		leftHash = []byte{0} // TypeScript: new Uint8Array(1)
 	}
 
 	if r.Right != nil {
-		rightHash = r.Right.calculateHash(algo).Data
+		rightHash = r.Right.calculateHash(hasher).RawHash
 	} else {
 		rightHash = []byte{0} // TypeScript: new Uint8Array(1)
 	}
 
 	// Combine and hash: leftHash + rightHash
-	combined := append(leftHash, rightHash...)
-	hashData := api.Sha256Hash(combined)
-
-	return api.NewDataHash(algo, hashData)
+	return hasher.Reset().AddData(leftHash).AddData(rightHash).GetHash()
 }
 
 // NewLeafBranch creates a leaf branch
@@ -183,16 +180,13 @@ func newLeafBranch(path *big.Int, value []byte) *LeafBranch {
 	}
 }
 
-func (l *LeafBranch) calculateHash(algo api.HashAlgorithm) *api.DataHash {
+func (l *LeafBranch) calculateHash(hasher *api.DataHasher) *api.DataHash {
 	if l.hash != nil {
 		return l.hash
 	}
 
 	pathBytes := api.BigintEncode(l.Path)
-	data := append(pathBytes, l.Value...)
-	hashData := api.Sha256Hash(data)
-
-	l.hash = api.NewDataHash(algo, hashData)
+	l.hash = hasher.Reset().AddData(pathBytes).AddData(l.Value).GetHash()
 	return l.hash
 }
 
@@ -214,24 +208,21 @@ func newNodeBranch(path *big.Int, left, right Branch) *NodeBranch {
 	}
 }
 
-func (n *NodeBranch) childrenHashData(algo api.HashAlgorithm) []byte {
-	return api.Sha256Hash(append(n.Left.calculateHash(algo).Data, n.Right.calculateHash(algo).Data...))
+func (n *NodeBranch) childrenHashData(hasher *api.DataHasher) *api.DataHash {
+	leftHash := n.Left.calculateHash(hasher)
+	rightHash := n.Right.calculateHash(hasher)
+	return hasher.Reset().AddData(leftHash.RawHash).AddData(rightHash.RawHash).GetHash()
 }
 
-func (n *NodeBranch) calculateHash(algo api.HashAlgorithm) *api.DataHash {
+func (n *NodeBranch) calculateHash(hasher *api.DataHasher) *api.DataHash {
 	if n.hash != nil {
 		return n.hash
 	}
 
 	// Recalculate if needed
-	childrenHashData := n.childrenHashData(algo)
-	n.childrenHash = api.NewDataHash(algo, childrenHashData)
-
+	n.childrenHash = n.childrenHashData(hasher)
 	pathBytes := api.BigintEncode(n.Path)
-	data := append(pathBytes, childrenHashData...)
-	hashData := api.Sha256Hash(data)
-	n.hash = api.NewDataHash(algo, hashData)
-
+	n.hash = hasher.Reset().AddData(pathBytes).AddData(n.childrenHash.RawHash).GetHash()
 	return n.hash
 }
 
@@ -319,12 +310,12 @@ func (smt *SparseMerkleTree) AddLeaves(leaves []*Leaf) error {
 
 // GetRootHash returns the root hash as imprint
 func (smt *SparseMerkleTree) GetRootHash() []byte {
-	return smt.root.calculateHash(smt.algorithm).Imprint
+	return smt.root.calculateHash(smt.hasher).GetImprint()
 }
 
 // GetRootHashHex returns the root hash as hex string
 func (smt *SparseMerkleTree) GetRootHashHex() string {
-	return smt.root.calculateHash(smt.algorithm).ToHex()
+	return smt.root.calculateHash(smt.hasher).ToHex()
 }
 
 // GetLeaf retrieves a leaf by path (for compatibility)
@@ -460,7 +451,7 @@ func (smt *SparseMerkleTree) buildTree(branch Branch, remainingPath *big.Int, va
 }
 
 func (smt *SparseMerkleTree) GetPath(path *big.Int) *api.MerkleTreePath {
-	rootHash := smt.root.calculateHash(smt.algorithm)
+	rootHash := smt.root.calculateHash(smt.hasher)
 	steps := smt.generatePath(path, smt.root.Left, smt.root.Right)
 
 	return &api.MerkleTreePath{
@@ -490,8 +481,8 @@ func (smt *SparseMerkleTree) generatePath(remainingPath *big.Int, left, right Br
 			Branch: nil, // nil indicates no branch exists
 		}
 		if siblingBranch != nil {
-			siblingHash := siblingBranch.calculateHash(smt.algorithm)
-			siblingHex := fmt.Sprintf("%x", siblingHash.Data) // Use only hash data without algorithm prefix
+			siblingHash := siblingBranch.calculateHash(smt.hasher)
+			siblingHex := fmt.Sprintf("%x", siblingHash.RawHash) // Use only hash data without algorithm prefix
 			step.Sibling = []string{siblingHex}
 		}
 		// If siblingBranch is nil, leave Sibling as nil (omitempty will exclude it from JSON)
@@ -551,7 +542,7 @@ func (smt *SparseMerkleTree) createMerkleTreeStep(path *big.Int, branch, sibling
 			step.Branch = []string{hex.EncodeToString(leafBranch.Value)}
 		} else {
 			// Otherwise use branch children hash data
-			step.Branch = []string{hex.EncodeToString(branch.(*NodeBranch).childrenHashData(smt.algorithm))}
+			step.Branch = []string{hex.EncodeToString(branch.(*NodeBranch).childrenHashData(smt.hasher).RawHash)}
 		}
 	} else {
 		// No branch, but we need to distinguish between:
@@ -563,8 +554,8 @@ func (smt *SparseMerkleTree) createMerkleTreeStep(path *big.Int, branch, sibling
 
 	// Add sibling hash if sibling exists
 	if siblingBranch != nil {
-		siblingHash := siblingBranch.calculateHash(smt.algorithm)
-		siblingHex := fmt.Sprintf("%x", siblingHash.Data) // Use only hash data without algorithm prefix
+		siblingHash := siblingBranch.calculateHash(smt.hasher)
+		siblingHex := fmt.Sprintf("%x", siblingHash.RawHash) // Use only hash data without algorithm prefix
 		step.Sibling = []string{siblingHex}
 	}
 	// If siblingBranch is nil, leave Sibling as nil (omitempty will exclude it from JSON)

--- a/internal/smt/smt_test.go
+++ b/internal/smt/smt_test.go
@@ -212,24 +212,6 @@ func TestSMTCommonPath(t *testing.T) {
 	}
 }
 
-// TestSMTDataHashFormat tests the DataHash format
-func TestSMTDataHashFormat(t *testing.T) {
-	data := []byte{0x1c, 0x84, 0xda, 0x4a}
-	hash := api.NewDataHash(api.SHA256, data)
-
-	expected := "00001c84da4a" // 0000 (api.SHA256) + 1c84da4a (data)
-	actual := hash.ToHex()
-
-	if actual != expected {
-		t.Errorf("DataHash format mismatch: expected %s, got %s", expected, actual)
-	}
-
-	// Verify algorithm imprint
-	if hash.Imprint[0] != 0 || hash.Imprint[1] != 0 {
-		t.Errorf("Algorithm bytes wrong: expected [0,0], got [%d,%d]", hash.Imprint[0], hash.Imprint[1])
-	}
-}
-
 // TestSMTBigintEncoding tests bigint encoding
 func TestSMTBigintEncoding(t *testing.T) {
 	testCases := []struct {

--- a/pkg/api/hash.go
+++ b/pkg/api/hash.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"log"
+)
+
+// HashAlgorithm identifies a hashing algorithm
+type HashAlgorithm int
+
+// Identifiers of known/supported hashing algorithms
+const (
+	SHA256 HashAlgorithm = 0 // SHA-2-256
+)
+
+// DataHash represents a hash value combined with the algorithm identifier
+type DataHash struct {
+	Algorithm HashAlgorithm
+	RawHash   []byte // Raw hash value
+	imprint   []byte // Combines the algorithm identifier and the hash value
+}
+
+// NewDataHash creates a DataHash from an algorithm identifier and a hash value
+func NewDataHash(algorithm HashAlgorithm, hash []byte) *DataHash {
+	return &DataHash{
+		Algorithm: algorithm,
+		RawHash:   append([]byte(nil), hash...),
+		// Imprint is computed on demand
+	}
+}
+
+// GetImprint computes and caches the imprint representation of the hash value
+func (h *DataHash) GetImprint() []byte {
+	if h.imprint == nil {
+		algorithm := uint(h.Algorithm)
+		h.imprint = make([]byte, len(h.RawHash)+2)
+		h.imprint[0] = byte(algorithm >> 8 & 0xff)
+		h.imprint[1] = byte(algorithm & 0xff)
+		copy(h.imprint[2:], h.RawHash)
+	}
+	return h.imprint
+}
+
+// ToHex returns the hex string representation of the hash imprint
+func (h *DataHash) ToHex() string {
+	return fmt.Sprintf("%x", h.GetImprint())
+}
+
+// DataHasher wraps a hash algorithm identifier and a corresponding hash function object
+type DataHasher struct {
+	// Identifies the hash algorithm
+	algorithm HashAlgorithm
+	// The hasher object used internally
+	hasher hash.Hash
+}
+
+// NewDataHasher creates a new DataHasher using the given algorithm
+func NewDataHasher(algorithm HashAlgorithm) *DataHasher {
+	switch algorithm {
+	case SHA256:
+		return &DataHasher{
+			algorithm: algorithm,
+			hasher:    sha256.New(),
+		}
+	default:
+		log.Printf("Unknown hash algorithm identifier %d\n", algorithm)
+		return nil
+	}
+}
+
+// GetAlgorithm returns the algorithm identifier
+func (h *DataHasher) GetAlgorithm() HashAlgorithm {
+	return h.algorithm
+}
+
+// AddData adds data to the hasher
+func (h *DataHasher) AddData(data []byte) *DataHasher {
+	h.hasher.Write(data) // hash.Hash.Write promises to never return errors
+	return h
+}
+
+// GetHash finalizes the computation and returns the hash value
+func (h *DataHasher) GetHash() *DataHash {
+	return NewDataHash(h.algorithm, h.hasher.Sum(nil))
+}
+
+// Reset resets the hasher to initial state
+func (h *DataHasher) Reset() *DataHasher {
+	h.hasher.Reset()
+	return h
+}

--- a/pkg/api/hash_test.go
+++ b/pkg/api/hash_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataHashGetImprint(t *testing.T) {
+	h := NewDataHash(SHA256, []byte{1, 2, 3})
+	expected := []byte{0, 0, 1, 2, 3}
+	assert.Equal(t, expected, h.GetImprint(), "Wrong imprint on first call")
+	assert.Equal(t, expected, h.imprint, "Imprint should be cached")
+	assert.Equal(t, expected, h.GetImprint(), "Wrong imprint on second call")
+}
+
+func TestDataHashToHex(t *testing.T) {
+	h := NewDataHash(SHA256, []byte{1, 2, 3})
+	assert.Equal(t, "0000010203", h.ToHex())
+}
+
+func TestNewDataHasher(t *testing.T) {
+	t.Run("Invalid algorithm identifier", func(t *testing.T) {
+		h := NewDataHasher(-1)
+		assert.Nil(t, h)
+	})
+
+	t.Run("SHA256 algorithm identifier", func(t *testing.T) {
+		h := NewDataHasher(SHA256)
+		assert.NotNil(t, h)
+		assert.Equal(t, SHA256, h.GetAlgorithm())
+	})
+}
+
+func TestSHA256Hashing(t *testing.T) {
+	t.Run("No input", func(t *testing.T) {
+		h := NewDataHasher(SHA256)
+		res := h.GetHash().ToHex()
+		expected := "0000e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		assert.Equal(t, expected, res)
+	})
+
+	// Some NIST test vectors
+	vectors := []struct {
+		data string
+		hash string
+	}{
+		{"", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{"d3", "28969cdfa74a12c82f3bad960b0b000aca2ac329deea5c2328ebc6f2ba9802c1"},
+		{"11af", "5ca7133fa735326081558ac312c620eeca9970d1e70a4b95533d956f072d1f98"},
+		{"b4190e", "dff2e73091f6c05e528896c4c831b9448653dc2ff043528f6769437bc7b975c2"},
+	}
+	for i, v := range vectors {
+		t.Run(fmt.Sprintf("Input %d", i), func(t *testing.T) {
+			h := NewDataHasher(SHA256)
+			d, _ := hex.DecodeString(v.data)
+			h.AddData(d)
+			res := h.GetHash().ToHex()
+			assert.Equal(t, "0000"+v.hash, res)
+		})
+	}
+
+	t.Run("Chaining", func(t *testing.T) {
+		h1 := NewDataHasher(SHA256)
+		res1 := h1.AddData([]byte{0, 1, 2}).GetHash()
+		h2 := NewDataHasher(SHA256)
+		res2 := h2.AddData([]byte{0}).AddData([]byte{1}).AddData([]byte{2}).GetHash()
+		assert.Equal(t, res1, res2)
+	})
+
+	t.Run("Reset", func(t *testing.T) {
+		d := []byte{1, 2, 3}
+		h := NewDataHasher(SHA256)
+		res1 := h.GetHash().ToHex()
+		h.AddData(d)
+		res2 := h.GetHash().ToHex()
+		h.Reset()
+		res3 := h.GetHash().ToHex()
+		h.AddData(d)
+		res4 := h.GetHash().ToHex()
+		assert.NotEqual(t, res1, res2) // Adding data mush change the hash
+		assert.Equal(t, res1, res3)    // Resetting must restore inital state
+		assert.Equal(t, res2, res4)    // State must change identically after reset
+	})
+}


### PR DESCRIPTION
Added a simple framework for hash functions
- lookups from algorithm identifiers to implementations (only SHA256 supported for now)
- SMT path verification now retrieves the algorithm identifier from the root hash imprint instead of hardcoding SHA256