### PR TITLE
Sharding: update child aggregator mode to latest smt changes

### DIFF
--- a/internal/ha/block_syncer.go
+++ b/internal/ha/block_syncer.go
@@ -18,11 +18,11 @@ type blockSyncer struct {
 	logger       *logger.Logger
 	storage      interfaces.Storage
 	smt          *smt.ThreadSafeSMT
-	shardID      int
+	shardID      api.ShardID
 	stateTracker *state.Tracker
 }
 
-func newBlockSyncer(logger *logger.Logger, storage interfaces.Storage, smt *smt.ThreadSafeSMT, shardID int, stateTracker *state.Tracker) *blockSyncer {
+func newBlockSyncer(logger *logger.Logger, storage interfaces.Storage, smt *smt.ThreadSafeSMT, shardID api.ShardID, stateTracker *state.Tracker) *blockSyncer {
 	return &blockSyncer{
 		logger:       logger,
 		storage:      storage,
@@ -99,7 +99,7 @@ func (bs *blockSyncer) updateSMTForBlock(ctx context.Context, blockRecord *model
 		}
 		uniqueRequestIds[key] = struct{}{}
 
-		path, err := reqID.GetPath(bs.shardID)
+		path, err := reqID.GetPath()
 		if err != nil {
 			return fmt.Errorf("failed to get path: %w", err)
 		}

--- a/internal/ha/block_syncer_test.go
+++ b/internal/ha/block_syncer_test.go
@@ -65,7 +65,7 @@ func createBlock(ctx context.Context, t *testing.T, storage *mongodb.Storage) ap
 	leaves := make([]*smt.Leaf, len(testCommitments))
 	records := make([]*models.AggregatorRecord, len(testCommitments))
 	for i, c := range testCommitments {
-		path, err := c.RequestID.GetPath(0)
+		path, err := c.RequestID.GetPath()
 		require.NoError(t, err)
 
 		val, err := c.CreateLeafValue()

--- a/internal/ha/ha_manager.go
+++ b/internal/ha/ha_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/unicitynetwork/aggregator-go/internal/logger"
 	"github.com/unicitynetwork/aggregator-go/internal/smt"
 	"github.com/unicitynetwork/aggregator-go/internal/storage/interfaces"
+	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
 
 type (
@@ -48,7 +49,7 @@ func NewHAManager(logger *logger.Logger,
 	leaderSelector LeaderSelector,
 	storage interfaces.Storage,
 	smt *smt.ThreadSafeSMT,
-	shardID int,
+	shardID api.ShardID,
 	stateTracker *state.Tracker,
 	syncInterval time.Duration,
 	disableBlockSync bool, // Set true for parent mode where block syncing is not needed

--- a/internal/models/block.go
+++ b/internal/models/block.go
@@ -14,7 +14,7 @@ import (
 type Block struct {
 	Index                *api.BigInt         `json:"index"`
 	ChainID              string              `json:"chainId"`
-	ShardID              int                 `json:"shardId"`
+	ShardID              api.ShardID         `json:"shardId"`
 	Version              string              `json:"version"`
 	ForkID               string              `json:"forkId"`
 	RootHash             api.HexBytes        `json:"rootHash"`
@@ -29,7 +29,7 @@ type Block struct {
 type BlockBSON struct {
 	Index               primitive.Decimal128 `bson:"index"`
 	ChainID             string               `bson:"chainId"`
-	ShardID             int                  `bson:"shardId"`
+	ShardID             api.ShardID          `bson:"shardId"`
 	Version             string               `bson:"version"`
 	ForkID              string               `bson:"forkId"`
 	RootHash            string               `bson:"rootHash"`

--- a/internal/round/adaptive_timing_test.go
+++ b/internal/round/adaptive_timing_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/unicitynetwork/aggregator-go/internal/ha/state"
 	"github.com/unicitynetwork/aggregator-go/internal/logger"
 	"github.com/unicitynetwork/aggregator-go/internal/models"
-	"github.com/unicitynetwork/aggregator-go/internal/storage/interfaces"
+	"github.com/unicitynetwork/aggregator-go/internal/smt"
 	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
 
@@ -36,7 +36,7 @@ func TestAdaptiveProcessingRatio(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create round manager
-	rm, err := NewRoundManager(context.Background(), cfg, testLogger, nil, nil, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(context.Background(), cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), nil, nil, nil, state.NewSyncStateTracker())
 	require.NoError(t, err)
 
 	// Test initial values
@@ -131,7 +131,7 @@ func TestAdaptiveDeadlineCalculation(t *testing.T) {
 	testLogger, err := logger.New("info", "text", "stdout", false)
 	require.NoError(t, err)
 
-	rm, err := NewRoundManager(context.Background(), cfg, testLogger, nil, nil, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(context.Background(), cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), nil, nil, nil, state.NewSyncStateTracker())
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -198,7 +198,7 @@ func TestSMTUpdateTimeTracking(t *testing.T) {
 	testLogger, err := logger.New("info", "text", "stdout", false)
 	require.NoError(t, err)
 
-	rm, err := NewRoundManager(context.Background(), cfg, testLogger, nil, nil, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(context.Background(), cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), nil, nil, nil, state.NewSyncStateTracker())
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -227,8 +227,8 @@ func TestSMTUpdateTimeTracking(t *testing.T) {
 				TransactionHash: api.ImprintHexString("0000" + hex.EncodeToString(txHashBytes)),
 				Authenticator: models.Authenticator{
 					Algorithm: "secp256k1",
-					PublicKey: api.HexBytes(append([]byte{0x02}, make([]byte, 32)...)),
-					Signature: api.HexBytes(make([]byte, 65)),
+					PublicKey: append([]byte{0x02}, make([]byte, 32)...),
+					Signature: make([]byte, 65),
 					StateHash: api.ImprintHexString("0000" + hex.EncodeToString(make([]byte, 32))),
 				},
 			}
@@ -261,7 +261,7 @@ func TestStreamingMetrics(t *testing.T) {
 	testLogger, err := logger.New("info", "text", "stdout", false)
 	require.NoError(t, err)
 
-	rm, err := NewRoundManager(context.Background(), cfg, testLogger, nil, nil, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(context.Background(), cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), nil, nil, nil, state.NewSyncStateTracker())
 	require.NoError(t, err)
 
 	// Set some test values
@@ -314,7 +314,7 @@ func TestAdaptiveTimingIntegration(t *testing.T) {
 	testLogger, err := logger.New("info", "text", "stdout", false)
 	require.NoError(t, err)
 
-	rm, err := NewRoundManager(context.Background(), cfg, testLogger, nil, nil, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(context.Background(), cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), nil, nil, nil, state.NewSyncStateTracker())
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -355,11 +355,4 @@ func TestAdaptiveTimingIntegration(t *testing.T) {
 			assert.LessOrEqual(t, rm.processingRatio, 0.95, "Processing ratio should not exceed 0.95")
 		})
 	}
-}
-
-// createMockStorage creates a mock storage for testing
-func createMockStorage(t *testing.T) interfaces.Storage {
-	// This is a simplified mock - in production you'd use a proper mock
-	// For now, we'll return nil which is fine since BFT is disabled
-	return nil
 }

--- a/internal/round/batch_processor.go
+++ b/internal/round/batch_processor.go
@@ -24,7 +24,7 @@ func (rm *RoundManager) processMiniBatch(ctx context.Context, commitments []*mod
 	leaves := make([]*smt.Leaf, 0, len(commitments))
 	for _, commitment := range commitments {
 		// Generate leaf path from requestID
-		path, err := commitment.RequestID.GetPath(rm.config.Sharding.Child.ShardID)
+		path, err := commitment.RequestID.GetPath()
 		if err != nil {
 			rm.logger.WithContext(ctx).Error("Failed to get path for commitment",
 				"requestID", commitment.RequestID.String(),

--- a/internal/round/factory.go
+++ b/internal/round/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/unicitynetwork/aggregator-go/internal/sharding"
 	"github.com/unicitynetwork/aggregator-go/internal/smt"
 	"github.com/unicitynetwork/aggregator-go/internal/storage/interfaces"
+	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
 
 // Manager interface for both standalone and parent round managers
@@ -25,12 +26,14 @@ type Manager interface {
 func NewManager(ctx context.Context, cfg *config.Config, logger *logger.Logger, commitmentQueue interfaces.CommitmentQueue, storage interfaces.Storage, stateTracker *state.Tracker) (Manager, error) {
 	switch cfg.Sharding.Mode {
 	case config.ShardingModeStandalone:
-		return NewRoundManager(ctx, cfg, logger, commitmentQueue, storage, nil, stateTracker)
+		smtInstance := smt.NewSparseMerkleTree(api.SHA256, 16+256)
+		return NewRoundManager(ctx, cfg, logger, smtInstance, commitmentQueue, storage, nil, stateTracker)
 	case config.ShardingModeParent:
 		return NewParentRoundManager(ctx, cfg, logger, storage)
 	case config.ShardingModeChild:
+		smtInstance := smt.NewChildSparseMerkleTree(api.SHA256, 16+256, cfg.Sharding.Child.ShardID)
 		rootAggregatorClient := sharding.NewRootAggregatorClient(cfg.Sharding.Child.ParentRpcAddr)
-		return NewRoundManager(ctx, cfg, logger, commitmentQueue, storage, rootAggregatorClient, stateTracker)
+		return NewRoundManager(ctx, cfg, logger, smtInstance, commitmentQueue, storage, rootAggregatorClient, stateTracker)
 	default:
 		return nil, fmt.Errorf("unsupported sharding mode: %s", cfg.Sharding.Mode)
 	}

--- a/internal/round/round_manager.go
+++ b/internal/round/round_manager.go
@@ -126,17 +126,13 @@ type RoundMetrics struct {
 }
 
 // NewRoundManager creates a new round manager
-func NewRoundManager(ctx context.Context, cfg *config.Config, logger *logger.Logger, commitmentQueue interfaces.CommitmentQueue, storage interfaces.Storage, rootAggregatorClient RootAggregatorClient, stateTracker *state.Tracker) (*RoundManager, error) {
-	// Initialize SMT with empty tree - will be replaced with restored tree in Start()
-	smtInstance := smt.NewSparseMerkleTree(api.SHA256, 16+256)
-	threadSafeSMT := smt.NewThreadSafeSMT(smtInstance)
-
+func NewRoundManager(ctx context.Context, cfg *config.Config, logger *logger.Logger, smtInstance *smt.SparseMerkleTree, commitmentQueue interfaces.CommitmentQueue, storage interfaces.Storage, rootAggregatorClient RootAggregatorClient, stateTracker *state.Tracker) (*RoundManager, error) {
 	rm := &RoundManager{
 		config:              cfg,
 		logger:              logger,
 		commitmentQueue:     commitmentQueue,
 		storage:             storage,
-		smt:                 threadSafeSMT,
+		smt:                 smt.NewThreadSafeSMT(smtInstance),
 		rootClient:          rootAggregatorClient,
 		stateTracker:        stateTracker,
 		roundDuration:       cfg.Processing.RoundDuration,         // Configurable round duration (default 1s)

--- a/internal/round/round_manager_test.go
+++ b/internal/round/round_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/unicitynetwork/aggregator-go/internal/ha/state"
 	"github.com/unicitynetwork/aggregator-go/internal/logger"
 	testsharding "github.com/unicitynetwork/aggregator-go/internal/sharding"
+	"github.com/unicitynetwork/aggregator-go/internal/smt"
 	"github.com/unicitynetwork/aggregator-go/internal/testutil"
 	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
@@ -43,7 +44,7 @@ func TestParentShardIntegration_GoodCase(t *testing.T) {
 	rootAggregatorClient := testsharding.NewRootAggregatorClientStub()
 
 	// create round manager
-	rm, err := NewRoundManager(ctx, &cfg, testLogger, storage.CommitmentQueue(), storage, rootAggregatorClient, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(ctx, &cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, rootAggregatorClient, state.NewSyncStateTracker())
 	require.NoError(t, err)
 
 	// start round manager
@@ -95,7 +96,7 @@ func TestParentShardIntegration_RoundProcessingError(t *testing.T) {
 	rootAggregatorClient.SetSubmissionError(errors.New("some error"))
 
 	// create round manager
-	rm, err := NewRoundManager(ctx, &cfg, testLogger, storage.CommitmentQueue(), storage, rootAggregatorClient, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(ctx, &cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, rootAggregatorClient, state.NewSyncStateTracker())
 	require.NoError(t, err)
 
 	// start round manager

--- a/internal/round/smt_persistence_integration_test.go
+++ b/internal/round/smt_persistence_integration_test.go
@@ -60,7 +60,7 @@ func TestSmtPersistenceAndRestoration(t *testing.T) {
 	testLogger, err := logger.New("info", "text", "stdout", false)
 	require.NoError(t, err)
 
-	rm, err := NewRoundManager(ctx, cfg, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 	require.NoError(t, err, "Should create RoundManager")
 
 	// Test persistence
@@ -79,7 +79,7 @@ func TestSmtPersistenceAndRestoration(t *testing.T) {
 	freshHash := freshSmt.GetRootHashHex()
 
 	// Create RoundManager and call Start() to trigger restoration
-	restoredRm, err := NewRoundManager(ctx, cfg, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+	restoredRm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 	require.NoError(t, err, "Should create RoundManager")
 
 	err = restoredRm.Start(ctx)
@@ -111,7 +111,7 @@ func TestLargeSmtRestoration(t *testing.T) {
 			RoundDuration: time.Second,
 		},
 	}
-	rm, err := NewRoundManager(ctx, cfg, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 	require.NoError(t, err, "Should create RoundManager")
 
 	const testNodeCount = 2500 // Ensure multiple chunks (chunkSize = 1000 in round_manager.go)
@@ -141,7 +141,7 @@ func TestLargeSmtRestoration(t *testing.T) {
 	require.Equal(t, int64(testNodeCount), count, "Should have stored all nodes")
 
 	// Create new RoundManager and call Start() to restore from storage (uses multiple chunks)
-	newRm, err := NewRoundManager(ctx, cfg, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+	newRm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 	require.NoError(t, err, "Should create new RoundManager")
 
 	err = newRm.Start(ctx)
@@ -176,7 +176,7 @@ func TestCompleteWorkflowWithRestart(t *testing.T) {
 	testLogger, err := logger.New("info", "text", "stdout", false)
 	require.NoError(t, err)
 
-	rm, err := NewRoundManager(ctx, cfg, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 	require.NoError(t, err, "Should create RoundManager")
 
 	rm.currentRound = &Round{
@@ -227,7 +227,8 @@ func TestCompleteWorkflowWithRestart(t *testing.T) {
 	assert.Equal(t, int64(len(testCommitments)), count, "Should have persisted SMT nodes for all commitments")
 
 	// Simulate service restart with new round manager
-	newRm, err := NewRoundManager(ctx, &config.Config{Processing: config.ProcessingConfig{RoundDuration: time.Second}}, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+	cfg = &config.Config{Processing: config.ProcessingConfig{RoundDuration: time.Second}}
+	newRm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 	require.NoError(t, err, "NewRoundManager should succeed after restart")
 
 	// Call Start() to trigger SMT restoration
@@ -241,7 +242,7 @@ func TestCompleteWorkflowWithRestart(t *testing.T) {
 
 	// Verify inclusion proofs work after restart
 	for _, commitment := range testCommitments {
-		path, err := commitment.RequestID.GetPath(0)
+		path, err := commitment.RequestID.GetPath()
 		require.NoError(t, err, "Should be able to get path from request ID")
 
 		merkleTreePath, err := newRm.smt.GetPath(path)
@@ -301,7 +302,7 @@ func TestSmtRestorationWithBlockVerification(t *testing.T) {
 	cfg := &config.Config{
 		Processing: config.ProcessingConfig{RoundDuration: time.Second},
 	}
-	rm, err := NewRoundManager(ctx, cfg, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+	rm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 	require.NoError(t, err, "Should create RoundManager")
 
 	// Persist SMT nodes to storage
@@ -310,7 +311,7 @@ func TestSmtRestorationWithBlockVerification(t *testing.T) {
 
 	// Test 1: Successful verification (matching root hash)
 	t.Run("SuccessfulVerification", func(t *testing.T) {
-		successRm, err := NewRoundManager(ctx, cfg, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+		successRm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 		require.NoError(t, err, "Should create RoundManager")
 
 		err = successRm.Start(ctx)
@@ -343,7 +344,7 @@ func TestSmtRestorationWithBlockVerification(t *testing.T) {
 		err = storage.BlockStorage().Store(ctx, wrongBlock)
 		require.NoError(t, err, "Should store wrong test block")
 
-		failRm, err := NewRoundManager(ctx, cfg, testLogger, storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
+		failRm, err := NewRoundManager(ctx, cfg, testLogger, smt.NewSparseMerkleTree(api.SHA256, 16+256), storage.CommitmentQueue(), storage, nil, state.NewSyncStateTracker())
 		require.NoError(t, err, "Should create RoundManager")
 
 		// This should fail because the restored SMT root hash doesn't match the latest block

--- a/internal/smt/smt.go
+++ b/internal/smt/smt.go
@@ -57,7 +57,7 @@ func NewChildSparseMerkleTree(algorithm api.HashAlgorithm, keyLength int, shardI
 	if shardID <= 1 {
 		panic("Shard ID must be positive and have at least 2 bits")
 	}
-	path := big.NewInt(shardID)
+	path := big.NewInt(int64(shardID))
 	if path.BitLen() > keyLength {
 		panic("Shard ID must be shorter than SMT key length")
 	}

--- a/internal/smt/smt_debug_test.go
+++ b/internal/smt/smt_debug_test.go
@@ -19,19 +19,14 @@ func TestAddLeaves_DebugInvalidPath(t *testing.T) {
 		commitment := &models.Commitment{}
 		require.NoError(t, json.Unmarshal(commJsonBytes, commitment))
 
-		path, err := commitment.RequestID.GetPath(0)
+		path, err := commitment.RequestID.GetPath()
 		require.NoError(t, err)
 
 		// Create leaf value (hash of commitment data)
 		leafValue, err := commitment.CreateLeafValue()
 		require.NoError(t, err)
 
-		leaf := &Leaf{
-			Path:  path,
-			Value: leafValue,
-		}
-
-		err = tree.AddLeaves([]*Leaf{leaf})
+		err = tree.AddLeaves([]*Leaf{NewLeaf(path, leafValue)})
 		require.NoError(t, err, "Expected error due to invalid path")
 
 		// now validate the path of request
@@ -83,7 +78,7 @@ func TestAddLeaves_DebugInvalidPath(t *testing.T) {
 	{
 		req, err := api.NewImprintHexString("00006df936060e07cad29086335623b2a05afef0b05f77dcc27f6e5065abce6f061d")
 		require.NoError(t, err, "Failed to create request ID")
-		path, err := req.GetPath(0)
+		path, err := req.GetPath()
 		require.NoError(t, err)
 		merkleTreePath, err := _smt.GetPath(path)
 		require.NoError(t, err)

--- a/pkg/api/merkle_tree_path_verify_test.go
+++ b/pkg/api/merkle_tree_path_verify_test.go
@@ -221,12 +221,12 @@ func TestMerkleTreePathVerify(t *testing.T) {
 
 		req1, err := api.NewImprintHexString(requestID1)
 		require.NoError(t, err)
-		path1, err := req1.GetPath(0)
+		path1, err := req1.GetPath()
 		require.NoError(t, err)
 
 		req2, err := api.NewImprintHexString(requestID2)
 		require.NoError(t, err)
-		path2, err := req2.GetPath(0)
+		path2, err := req2.GetPath()
 		require.NoError(t, err)
 
 		// Add to tree

--- a/pkg/api/request_id.go
+++ b/pkg/api/request_id.go
@@ -16,18 +16,13 @@ type RequestID = ImprintHexString
 // ImprintHexString represents a hex string (4 chars (two bytes) algorithm + n-byte chars hash)
 type ImprintHexString string
 
-func (r RequestID) GetPath(shardID int) (*big.Int, error) {
+func (r RequestID) GetPath() (*big.Int, error) {
 	// Converts RequestID hex string to a big.Int for use as an SMT path.
 	// Prefixes with "0x01" to preserve leading zero bits in the original hex string,
 	// ensuring consistent path representation in the Sparse Merkle Tree.
 	path, ok := new(big.Int).SetString("0x01"+string(r), 0)
 	if !ok {
 		return nil, fmt.Errorf("failed to convert requestID %s to path", r)
-	}
-	// remove (rightmost) shard identifier bits if sharding is enabled
-	if shardID != 0 {
-		n := big.NewInt(0).SetInt64(int64(shardID)).BitLen() - 1
-		path.Rsh(path, uint(n))
 	}
 	return path, nil
 }

--- a/pkg/api/request_id_test.go
+++ b/pkg/api/request_id_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -601,50 +600,6 @@ func TestImprintHexString_BSONComprehensive(t *testing.T) {
 			}
 
 			t.Logf("✓ %s: %s -> BSON -> %s", tc.description, string(tc.value), string(unmarshaledDoc.Value))
-		})
-	}
-}
-
-func TestRequestID_GetPath(t *testing.T) {
-	testCases := []struct {
-		name      string
-		reqID     string
-		shardID   int
-		resultInt int
-	}{
-		{name: "no sharding 1", reqID: "00", shardID: 0, resultInt: 0b100000000}, // 0x0100 >> 0
-		{name: "no sharding 2", reqID: "01", shardID: 0, resultInt: 0b100000001}, // 0x0101 >> 0
-		{name: "no sharding 3", reqID: "FF", shardID: 0, resultInt: 0b111111111}, // 0x01FF >> 0
-
-		{name: "two shards 1 (rightmost bit is removed)", reqID: "00", shardID: 0b10, resultInt: 0b10000000}, // 0x0100 >> 1
-		{name: "two shards 2 (rightmost bit is removed)", reqID: "00", shardID: 0b11, resultInt: 0b10000000}, // 0x0100 >> 1
-		{name: "two shards 3 (rightmost bit is removed)", reqID: "01", shardID: 0b10, resultInt: 0b10000000}, // 0x0101 >> 1
-		{name: "two shards 4 (rightmost bit is removed)", reqID: "01", shardID: 0b11, resultInt: 0b10000000}, // 0x0101 >> 1
-		{name: "two shards 5 (rightmost bit is removed)", reqID: "FF", shardID: 0b10, resultInt: 0b11111111}, // 0x01FF >> 1
-		{name: "two shards 6 (rightmost bit is removed)", reqID: "FF", shardID: 0b11, resultInt: 0b11111111}, // 0x01FF >> 1
-
-		{name: "three shards 1 (2 rightmost bits removed)", reqID: "00", shardID: 0b100, resultInt: 0b1000000}, // 0x0100 >> 2
-		{name: "three shards 2 (2 rightmost bits removed)", reqID: "00", shardID: 0b101, resultInt: 0b1000000},
-		{name: "three shards 3 (2 rightmost bits removed)", reqID: "00", shardID: 0b110, resultInt: 0b1000000},
-		{name: "three shards 4 (2 rightmost bits removed)", reqID: "00", shardID: 0b111, resultInt: 0b1000000},
-		{name: "three shards 5 (2 rightmost bits removed)", reqID: "01", shardID: 0b100, resultInt: 0b1000000}, // 0x0101 >> 2
-		{name: "three shards 6 (2 rightmost bits removed)", reqID: "01", shardID: 0b101, resultInt: 0b1000000},
-		{name: "three shards 7 (2 rightmost bits removed)", reqID: "01", shardID: 0b110, resultInt: 0b1000000},
-		{name: "three shards 8 (2 rightmost bits removed)", reqID: "01", shardID: 0b111, resultInt: 0b1000000},
-		{name: "three shards 9 (2 rightmost bits removed)", reqID: "FF", shardID: 0b100, resultInt: 0b1111111}, // 0x01FF >> 2
-		{name: "three shards 10 (2 rightmost bits removed)", reqID: "FF", shardID: 0b101, resultInt: 0b1111111},
-		{name: "three shards 11 (2 rightmost bits removed)", reqID: "FF", shardID: 0b110, resultInt: 0b1111111},
-		{name: "three shards 12 (2 rightmost bits removed)", reqID: "FF", shardID: 0b111, resultInt: 0b1111111},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			requestID := ImprintHexString(tc.reqID)
-			path, err := requestID.GetPath(tc.shardID)
-			require.NoError(t, err)
-
-			expectedPath := big.NewInt(0).SetInt64(int64(tc.resultInt))
-			assert.Equal(t, expectedPath, path)
 		})
 	}
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -12,7 +12,7 @@ import (
 // Basic types for API
 type StateHash = ImprintHexString
 type TransactionHash = ImprintHexString
-type ShardID = int64
+type ShardID = int
 
 // Authenticator represents the authentication data for a commitment
 type Authenticator struct {
@@ -122,7 +122,7 @@ func NewAggregatorRecord(commitment *Commitment, blockNumber, leafIndex *BigInt)
 type Block struct {
 	Index                *BigInt         `json:"index"`
 	ChainID              string          `json:"chainId"`
-	ShardID              int             `json:"shardId"`
+	ShardID              ShardID         `json:"shardId"`
 	Version              string          `json:"version"`
 	ForkID               string          `json:"forkId"`
 	RootHash             HexBytes        `json:"rootHash"`


### PR DESCRIPTION
- join parent and child merkle paths in inclusion proof
- request id shard bits are now managed internally in the SMT
- set shardID type alias from int64 to int
- use shardID type alias instead of int