### PR TITLE
improve redis stream handling and consumer group recovery

### DIFF
--- a/internal/models/commitment.go
+++ b/internal/models/commitment.go
@@ -19,6 +19,7 @@ type Commitment struct {
 	AggregateRequestCount uint64              `json:"aggregateRequestCount" bson:"aggregateRequestCount"`
 	CreatedAt             *api.Timestamp      `json:"createdAt" bson:"createdAt"`
 	ProcessedAt           *api.Timestamp      `json:"processedAt,omitempty" bson:"processedAt,omitempty"`
+	StreamID              string              `json:"-" bson:"-"` // Redis stream ID used for stream acknowledgements
 }
 
 // Authenticator represents the authentication data for a commitment

--- a/internal/round/batch_processor.go
+++ b/internal/round/batch_processor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/unicitynetwork/aggregator-go/internal/models"
 	"github.com/unicitynetwork/aggregator-go/internal/smt"
+	"github.com/unicitynetwork/aggregator-go/internal/storage/interfaces"
 	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
 
@@ -140,6 +141,7 @@ func (rm *RoundManager) FinalizeBlock(ctx context.Context, block *models.Block) 
 	var processingTime time.Duration
 	var markProcessedStart, storeBlockStart, persistDataStart, commitSnapshotStart time.Time
 	var markProcessedTime, storeBlockTime, persistDataTime, commitSnapshotTime time.Duration
+	commitmentCount := 0
 
 	// Get timing metrics from the round if available
 	rm.roundMutex.Lock()
@@ -152,38 +154,43 @@ func (rm *RoundManager) FinalizeBlock(ctx context.Context, block *models.Block) 
 	// CRITICAL: Store all commitment data BEFORE storing the block to prevent race conditions
 	// where API returns partial block data
 
-	// First, collect all request IDs that will be in this block
+	// First, collect all request IDs and stream metadata that will be in this block
 	rm.roundMutex.Lock()
 	requestIds := make([]api.RequestID, 0)
+	ackEntries := make([]interfaces.CommitmentAck, 0)
+	pendingRecordCount := 0
+	roundNumber := block.Index.String()
+
 	if rm.currentRound != nil {
-		requestIds = make([]api.RequestID, 0, len(rm.currentRound.Commitments))
-		for _, commitment := range rm.currentRound.Commitments {
-			requestIds = append(requestIds, commitment.RequestID)
+		if rm.currentRound.Number != nil {
+			roundNumber = rm.currentRound.Number.String()
+		}
+		commitmentCount = len(rm.currentRound.Commitments)
+		pendingRecordCount = len(rm.currentRound.PendingRecords)
+
+		requestIds = make([]api.RequestID, commitmentCount)
+		ackEntries = make([]interfaces.CommitmentAck, commitmentCount)
+
+		for i, commitment := range rm.currentRound.Commitments {
+			requestIds[i] = commitment.RequestID
+			ackEntries[i] = interfaces.CommitmentAck{RequestID: commitment.RequestID, StreamID: commitment.StreamID}
 		}
 	}
 	rm.roundMutex.Unlock()
 
-	rm.roundMutex.Lock()
-	if rm.currentRound != nil && len(rm.currentRound.Commitments) > 0 {
+	if commitmentCount > 0 {
 		rm.logger.WithContext(ctx).Debug("Preparing commitment data before block storage",
-			"roundNumber", rm.currentRound.Number.String(),
-			"commitmentCount", len(rm.currentRound.Commitments),
-			"recordCount", len(rm.currentRound.PendingRecords))
-
-		// Extract data we need
-		requestIDs := make([]api.RequestID, len(rm.currentRound.Commitments))
-		for i, commitment := range rm.currentRound.Commitments {
-			requestIDs[i] = commitment.RequestID
-		}
-		rm.roundMutex.Unlock()
+			"roundNumber", roundNumber,
+			"commitmentCount", commitmentCount,
+			"recordCount", pendingRecordCount)
 
 		// Note: Aggregator records are now stored during processBatch, not here
 		rm.logger.WithContext(ctx).Debug("Aggregator records already stored during batch processing",
-			"commitmentCount", len(requestIDs))
+			"commitmentCount", commitmentCount)
 
-		// Mark commitments as processed BEFORE storing the block
 		markProcessedStart = time.Now()
-		if err := rm.commitmentQueue.MarkProcessed(ctx, requestIDs); err != nil {
+
+		if err := rm.commitmentQueue.MarkProcessed(ctx, ackEntries); err != nil {
 			rm.logger.WithContext(ctx).Error("Failed to mark commitments as processed",
 				"error", err.Error(),
 				"blockNumber", block.Index.String())
@@ -192,11 +199,8 @@ func (rm *RoundManager) FinalizeBlock(ctx context.Context, block *models.Block) 
 		markProcessedTime = time.Since(markProcessedStart)
 
 		rm.logger.WithContext(ctx).Info("Successfully prepared commitment data",
-			"count", len(requestIDs),
+			"count", commitmentCount,
 			"blockNumber", block.Index.String())
-
-	} else {
-		rm.roundMutex.Unlock()
 	}
 
 	// Store the block first - before committing the snapshot
@@ -316,7 +320,7 @@ func (rm *RoundManager) FinalizeBlock(ctx context.Context, block *models.Block) 
 
 	// Get commitment count for performance summary
 	rm.roundMutex.RLock()
-	commitmentCount := 0
+	commitmentCount = 0
 	if rm.currentRound != nil {
 		commitmentCount = len(rm.currentRound.Commitments)
 	}

--- a/internal/storage/interfaces/interfaces.go
+++ b/internal/storage/interfaces/interfaces.go
@@ -25,7 +25,7 @@ type CommitmentQueue interface {
 	StreamCommitments(ctx context.Context, commitmentChan chan<- *models.Commitment) error
 
 	// MarkProcessed marks commitments as processed
-	MarkProcessed(ctx context.Context, requestIDs []api.RequestID) error
+	MarkProcessed(ctx context.Context, entries []CommitmentAck) error
 
 	// Delete removes processed commitments
 	Delete(ctx context.Context, requestIDs []api.RequestID) error
@@ -39,6 +39,12 @@ type CommitmentQueue interface {
 	// Lifecycle methods
 	Initialize(ctx context.Context) error
 	Close(ctx context.Context) error
+}
+
+// CommitmentAck represents the metadata required to acknowledge a commitment.
+type CommitmentAck struct {
+	RequestID api.RequestID
+	StreamID  string
 }
 
 // AggregatorRecordStorage handles finalized aggregator records

--- a/internal/storage/mongodb/commitment.go
+++ b/internal/storage/mongodb/commitment.go
@@ -11,6 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/unicitynetwork/aggregator-go/internal/models"
+	"github.com/unicitynetwork/aggregator-go/internal/storage/interfaces"
 	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
 
@@ -109,9 +110,14 @@ func (cs *CommitmentStorage) GetUnprocessedBatchWithCursor(ctx context.Context, 
 }
 
 // MarkProcessed marks commitments as processed
-func (cs *CommitmentStorage) MarkProcessed(ctx context.Context, requestIDs []api.RequestID) error {
-	if len(requestIDs) == 0 {
+func (cs *CommitmentStorage) MarkProcessed(ctx context.Context, entries []interfaces.CommitmentAck) error {
+	if len(entries) == 0 {
 		return nil
+	}
+
+	requestIDs := make([]api.RequestID, len(entries))
+	for i, entry := range entries {
+		requestIDs[i] = entry.RequestID
 	}
 
 	filter := bson.M{"requestId": bson.M{"$in": requestIDs}}

--- a/internal/storage/redis/test_helpers.go
+++ b/internal/storage/redis/test_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/unicitynetwork/aggregator-go/internal/models"
 	"github.com/unicitynetwork/aggregator-go/internal/signing"
+	"github.com/unicitynetwork/aggregator-go/internal/storage/interfaces"
 	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
 
@@ -60,4 +61,15 @@ func createTestCommitment() *models.Commitment {
 		TransactionHash:       api.TransactionHash(transactionHashImprint),
 		AggregateRequestCount: 1,
 	}
+}
+
+func toAckEntries(commitments []*models.Commitment) []interfaces.CommitmentAck {
+	acks := make([]interfaces.CommitmentAck, len(commitments))
+	for i, commitment := range commitments {
+		acks[i] = interfaces.CommitmentAck{
+			RequestID: commitment.RequestID,
+			StreamID:  commitment.StreamID,
+		}
+	}
+	return acks
 }


### PR DESCRIPTION
* recreate redis consumer group if it is deleted
* use individual stream ID-s when marking commitments as processed instead of relying on ordering