### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bft-config
 /data/
 /logs/
 .cache/
+.gocache/
 
 # Environment files with secrets
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,227 +4,123 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Go rewrite of the TypeScript aggregator service located in the `aggregator-ts/` folder. The goal is to create a more scalable and performant implementation while preserving all functional requirements.
+High-performance Go aggregator service for the Unicity blockchain platform. Core features: JSON-RPC 2.0 API, MongoDB persistence, HA with leader election, BFT consensus integration, round-based block creation.
 
 ## Development Commands
 
-### TypeScript Reference Implementation
 ```bash
-# Navigate to TypeScript implementation
-cd aggregator-ts/
+# Build and run
+make build                    # Build to bin/aggregator
+make run                      # Build and run
+go test ./...                 # Run all tests
+go test -race ./...           # Run tests with race detection
+go test -bench=. ./...        # Run benchmarks
 
-# Install dependencies
-npm install
+# Run single test
+go test -v -run TestName ./path/to/package
 
-# Build the project
-npm run build
+# Docker development
+make docker-run-clean         # Clean rebuild (stops, removes data, rebuilds)
+make docker-run-clean-keep-tb # Rebuild but preserve BFT trust base config
+make docker-restart-aggregator # Rebuild just the aggregator service
 
-# Start the service
-npm run start
+# Sharding setups
+make docker-run-sh-clean-keep-tb    # Sharded setup (parent + 2 children)
+make docker-run-sh-ha-clean-keep-tb # Sharded + HA setup
 
-# Run tests
-npm run test
+# Performance testing
+make performance-test                                           # Local standalone test
+make performance-test-auth URL=http://host:port AUTH='Bearer x' # Remote with auth
 
-# Run tests without Docker dependencies
-npm run test:no-docker
-
-# Run linting
-npm run lint
-
-# Run benchmarks
-npm run benchmark
-
-# Start MongoDB for testing
-npm run docker:mongo
-
-# Start Alphabill for integration tests
-npm run docker:alphabill
-```
-
-### Go Implementation
-```bash
-# Build the Go service
-go build -o aggregator ./cmd/aggregator
-
-# Run tests
-go test ./...
-
-# Run tests with race detection
-go test -race ./...
-
-# Run benchmarks
-go test -bench=. ./...
-
-# Format code
-go fmt ./...
-
-# Run the service and connect to MongoDB running on localhost
-MONGODB_URI=mongodb://admin:password@localhost:27017/aggregator?authSource=admin make run
-
-# Run the performance test (IMPORTANT: Always use make, not direct binary)
-make performance-test
+# Sharded performance test (provide shard targets with shardID suffix)
+SHARD_TARGETS="http://localhost:3001:3,http://localhost:3002:2" TEST_DURATION=10s REQUESTS_PER_SEC=100 go run ./cmd/performance-test
 ```
 
 ## Architecture Overview
 
 ### Core Components
-- **AggregatorGateway**: Main service orchestrator handling HTTP server lifecycle and subsystem coordination
-- **AggregatorService**: Business logic layer for commitment validation and proof generation
-- **RoundManager**: Block creation orchestrator that batches commitments and coordinates with consensus
-- **Storage Layer**: Interface-based abstraction with MongoDB implementations for various data types
-- **High Availability**: Leader election system for distributed processing with automatic failover
-- **Consensus Integration**: Alphabill blockchain integration for finality
+- **gateway.Server** (`internal/gateway/server.go`): HTTP server with Gin, JSON-RPC routing
+- **service.AggregatorService** (`internal/service/service.go`): Business logic, commitment validation
+- **service.ParentAggregatorService** (`internal/service/parent_service.go`): Parent mode shard aggregation
+- **round.RoundManager** (`internal/round/round_manager.go`): Block creation orchestrator, 1-second rounds
+- **round.ParentRoundManager** (`internal/round/parent_round_manager.go`): Parent mode round management
+- **smt.ThreadSafeSMT** (`internal/smt/thread_safe_smt.go`): Sparse Merkle Tree with snapshots
+- **ha.LeaderElection** (`internal/ha/leader_election.go`): MongoDB-based leader election
 
 ### Key Data Flow
-1. Client submits commitment via JSON-RPC API
-2. Commitment validated and stored temporarily
-3. RoundManager batches commitments (1000 per batch) every second
-4. SMT updated with new commitments in parallel
-5. Root hash submitted to Alphabill consensus
+1. Client submits commitment via JSON-RPC → validation via `signing.CommitmentValidator`
+2. Commitment stored in queue (MongoDB or Redis based on config)
+3. RoundManager batches commitments every second (up to `BATCH_LIMIT`)
+4. SMT updated with new commitments in parallel batches
+5. Root hash submitted to BFT consensus
 6. Block created with transaction proof and stored
 7. Inclusion proofs generated from SMT for queries
 
-### Storage Abstractions
-- **IBlockStorage**: Blockchain blocks with transaction proofs
-- **IAggregatorRecordStorage**: Finalized commitment records
-- **ICommitmentStorage**: Temporary commitments with cursor-based processing
-- **ISmtStorage**: Sparse Merkle Tree nodes
-- **IBlockRecordsStorage**: Block number to request ID mappings
-- **ILeadershipStorage**: High availability leader election state
+### Sharding Architecture
 
-### High Availability System
-- MongoDB-based leader election with TTL locks
-- Only leader processes blocks while all servers handle API requests
-- Heartbeat mechanism with automatic failover
-- Configurable via environment variables (DISABLE_HIGH_AVAILABILITY, LOCK_TTL_SECONDS, etc.)
+Three operating modes configured via `SHARDING_MODE`:
+- **standalone**: Original mode - processes commitments directly from clients
+- **parent**: Aggregates child aggregator root hashes into parent SMT
+- **child**: Validates commitment belongs to shard, submits roots to parent
+
+Parent mode uses `submit_shard_root` and `get_shard_proof` APIs instead of commitment APIs.
+
+ShardID format: Uses `1` as MSB prefix (e.g., `0b10` for shard 0, `0b11` for shard 1 with `SHARD_ID_LENGTH=1`).
+
+### Storage Layer
+
+Interface-based abstraction in `internal/storage/interfaces/interfaces.go`:
+- **CommitmentQueue**: Pending commitments (MongoDB or Redis)
+- **AggregatorRecordStorage**: Finalized commitment records
+- **BlockStorage**: Blockchain blocks with BFT proofs
+- **SmtStorage**: Sparse Merkle Tree leaf nodes
+- **BlockRecordsStorage**: Block number to request ID mappings
+- **LeadershipStorage**: HA leader election state
+- **TrustBaseStorage**: BFT trust base configuration
 
 ## Key Dependencies
 
-### TypeScript Implementation
-- `@alphabill/alphabill-js-sdk`: Blockchain consensus integration
-- `@unicitylabs/commons`: Core cryptographic and data structures
-- `mongodb/mongoose`: Primary data persistence
-- `express.js`: HTTP API server
-- `winston`: Structured logging
+- `github.com/gin-gonic/gin`: HTTP router
+- `go.mongodb.org/mongo-driver`: MongoDB driver
+- `github.com/btcsuite/btcd/btcec/v2`: secp256k1 cryptography
+- `github.com/unicitynetwork/bft-core`: BFT consensus client
+- `github.com/testcontainers/testcontainers-go`: Integration test infrastructure
 
-### Go Implementation Dependencies (To be selected)
-- MongoDB driver (official Go MongoDB driver)
-- HTTP router (gin, echo, or standard library)
-- Structured logging (logrus, zap, or slog)
-- Cryptographic libraries for SMT and signature verification
-- gRPC/HTTP client for Alphabill integration
+## Testing
+
+Integration tests use testcontainers for MongoDB/Redis. Tests with `_test.go` suffix alongside source files.
+
+Key test files:
+- `internal/round/round_manager_test.go`: Block creation flow
+- `internal/service/parent_service_test.go`: Parent mode operations
+- `internal/smt/smt_test.go`: SMT operations and TypeScript compatibility
+- `internal/storage/mongodb/*_test.go`: Storage layer tests
 
 ## Critical Implementation Notes
 
-### Concurrency Patterns
-- TypeScript uses async/await extensively - translate to goroutines and channels
-- SMT operations require locking mechanism for thread safety
-- Cursor-based commitment processing needs careful state management
-- Block creation process must be atomic and coordinated
+### SMT Snapshot Pattern
+Create snapshot at round start → add leaves → commit only after block storage succeeds. See `internal/smt/thread_safe_smt_snapshot.go`.
 
-### Error Handling
-- Comprehensive error wrapping and structured error responses
-- JSON-RPC 2.0 error code compliance
-- Graceful degradation patterns for consensus failures
-- Proper context cancellation for HTTP requests
+### Commitment Validation Order
+1. Algorithm check (secp256k1 only)
+2. Public key format (33-byte compressed)
+3. StateHash DataHash format ("0000" SHA256 prefix)
+4. RequestID = SHA256(publicKey || stateHash)
+5. Signature format (65 bytes)
+6. TransactionHash format
+7. Signature cryptographic verification
+8. Shard validation (child mode only)
 
-### Performance Considerations
-- Batch operations for database efficiency
-- Parallel SMT updates during block creation
-- Configurable concurrency limits for API requests
-- Memory-efficient cursor-based processing
-
-### Configuration Management
-- Environment variable based configuration with validation
-- Default values and validation for all settings
-- Structured configuration objects
-- High availability settings (leader election, heartbeat intervals)
-
-## Testing Strategy
-
-### Test Organization
-- Unit tests for individual components with proper mocking
-- Integration tests with real MongoDB (use testcontainers)
-- High availability tests for leader election scenarios
-- Benchmark tests for performance-critical paths
-- API tests for JSON-RPC compliance
-
-### Test Infrastructure
-- Use testcontainers for MongoDB and Alphabill dependencies
-- Mock implementations for external services
-- Comprehensive error scenario testing
-- Performance regression testing
-
-## JSON-RPC API Specification
-
-All endpoints follow JSON-RPC 2.0 specification:
-
-### Core Methods
-- `submit_commitment`: Submit state transition request
-- `get_inclusion_proof`: Retrieve merkle proof for commitment
-- `get_no_deletion_proof`: Get global no-deletion proof (not implemented)
-- `get_block_height`: Current block number
-- `get_block`: Block data by number or "latest"
-- `get_block_commitments`: All commitments in specific block
-
-### Infrastructure Endpoints
-- `GET /health`: Service health and leader status
-- `GET /docs`: API documentation
-
-## MongoDB Schema Design
-
-### Critical Collections
-- **blocks**: Chain metadata with transaction proofs
-- **aggregator_records**: Finalized commitments with authenticators
-- **commitments**: Temporary storage with cursor state
-- **smt_nodes**: Sparse merkle tree leaf nodes
-- **block_records**: Block number to request ID mappings
-- **leadership**: High availability leader election state
-
-### Schema Patterns
-- Custom BigInt and Uint8Array serialization
-- Indexed fields for efficient queries
-- Unique constraints for data integrity
-- Atomic operations for critical state changes
+### BFT Integration
+BFT client in `internal/bft/client.go` connects to consensus network. Trust bases loaded from files at startup and can be dynamically added via `/api/v1/trustbases` endpoint.
 
 ---
 
-# Development Guidelines & Reminders
+## Development Guidelines
 
-## Documentation Best Practices
-**CRITICAL REMINDER**: Always keep README.md synchronized with code changes!
+### Documentation
+- Keep README.md synchronized with code changes
+- Append changelog entries to `changes.txt` with format: "CHANGELOG ENTRY - Day Month Year at Time CET"
 
-### When making ANY changes to the codebase:
-1. **Update README immediately** after implementing features
-2. **Document new API endpoints** as soon as they're created
-3. **Update architecture diagrams** when adding/modifying files
-4. **Add new environment variables** to configuration section
-5. **Include new dependencies** in setup instructions
-
-### Documentation workflow:
-- Add README updates to todo lists when planning features
-- Document endpoints, types, and components concurrently with implementation
-- Keep usage examples current with actual functionality
-- Update limitations and known issues as they're discovered
-- **ALWAYS append changelog entries to changes.txt with human-readable timestamps**
-
-### Changelog Requirements:
-- After completing any significant changes, append to `changes.txt`
-- Include timestamp in format: "CHANGELOG ENTRY - Day Month Year at Time CET"
-- Document what was changed, why, and any important technical details
-- Keep entries clear and concise for future reference
-
-This ensures documentation stays accurate and useful for future development sessions.
-
-## Important Development Reminders
-
-### Performance Testing
-- **ALWAYS use `make performance-test`** to run the performance test, not the direct binary
-- The make target ensures proper environment setup and consistent execution
-- Performance test tracks only commitments submitted in the current run for accurate metrics
-
-### Docker Compose Management
-- **Clean rebuild**: `make docker-run-clean`
-- This stops containers, removes data, and rebuilds everything fresh
-
-This ensures documentation stays accurate and useful for future development sessions.
+### Important Reminders
+- **Clean rebuild**: `make docker-run-clean` stops containers, removes data, rebuilds fresh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Unicity Aggregator - Go Implementation
+# Unicity Aggregator
 
-This is a high-performance Go rewrite of the TypeScript aggregator service for the Unicity blockchain platform. The service provides JSON-RPC 2.0 API endpoints for state transition aggregation with MongoDB persistence and high availability support.
+High-performance aggregator service for the Unicity blockchain platform. Provides JSON-RPC 2.0 API endpoints for state transition aggregation with MongoDB persistence, BFT consensus integration, and high availability support.
 
 ## Overview
 
@@ -17,8 +17,8 @@ The Unicity Aggregator implements a decentralized Agent-Aggregator communication
 - ✅ **MongoDB Integration** - Efficient storage with proper indexing
 - ✅ **High Availability** - Leader election and distributed processing
 - ✅ **Signature Validation** - Full secp256k1 cryptographic validation for commitments
-- ✅ **SMT Integration** - Sparse Merkle Tree for inclusion proofs with TypeScript compatibility
-- ✅ **Round Management** - Automated 1-second block creation with batch processing
+- ✅ **SMT Integration** - Sparse Merkle Tree for inclusion proofs
+- ✅ **Round Management** - Automated block creation with batch processing
 - ✅ **DataHash Support** - Proper algorithm imprint format for SHA256 hashes
 - ✅ **Configurable Concurrency** - Request rate limiting and parallel processing
 - ✅ **Graceful Shutdown** - Proper resource cleanup on termination
@@ -26,7 +26,7 @@ The Unicity Aggregator implements a decentralized Agent-Aggregator communication
 - ✅ **TLS Support** - HTTPS/TLS configuration for production
 - ✅ **CORS Support** - Cross-origin resource sharing for web clients
 - ✅ **Performance Testing** - Built-in performance test with cryptographically valid data
-- 🚧 **Consensus Integration** - Alphabill blockchain submission (planned)
+- ✅ **BFT Consensus** - Integration with Unicity BFT network for block finalization
 
 ## Quick Start
 
@@ -532,13 +532,9 @@ aggregator-go/
 │   │   └── mongodb/       # MongoDB implementations
 │   ├── models/            # Data models and types
 │   └── logger/            # Logging utilities
-├── pkg/                   # Public/reusable packages
-│   └── jsonrpc/          # JSON-RPC server implementation
-├── tests/                 # Comprehensive test suites
-│   ├── api/              # API compatibility tests
-│   ├── benchmarks/       # Performance benchmarks
-│   └── integration/      # Integration tests
-└── aggregator-ts/        # TypeScript reference implementation
+└── pkg/                   # Public/reusable packages
+    ├── api/              # Public API types
+    └── jsonrpc/          # JSON-RPC server implementation
 ```
 
 ### Database Collections
@@ -564,6 +560,9 @@ make performance-test
 
 # Run performance test against a remote endpoint with authentication
 make performance-test-auth URL=http://localhost:8080 AUTH='Bearer supersecret'
+
+# Sharded performance test (provide shard targets with shardID suffix)
+SHARD_TARGETS="http://localhost:3001:3,http://localhost:3002:2" TEST_DURATION=10s REQUESTS_PER_SEC=100 go run ./cmd/performance-test
 ```
 
 **Performance Test Features:**
@@ -751,30 +750,19 @@ The service implements complete secp256k1 signature validation:
 ## Architecture Notes
 
 ### Round Management
-- **1-second rounds** - Automated block creation every second
+- **Round-based processing** - Automated block creation
 - **Batch processing** - Multiple commitments per block
 - **Leader-only block creation** - High availability with single leader
 - **Graceful shutdown** - Proper cleanup of pending rounds
 
 ### SMT Integration
-- **TypeScript compatibility** - Exact hash matching with reference implementation
-- **Production performance** - 90,000+ leaves/second processing capability
+- **Spec compliant** - Exact hash matching with Unicity SMT specification
 - **Memory efficient** - Optimized for large-scale operations
 - **Concurrent safe** - Thread-safe operations with proper locking
 
 ## Limitations
 
-- **Consensus Integration**: No Alphabill submission yet (implementation pending)
 - **Receipt Signing**: Returns unsigned receipts (cryptographic signing planned)
-
-## Migration from TypeScript
-
-This Go implementation maintains API compatibility with the TypeScript version while providing:
-
-- **Better Performance**: Native compiled binary with efficient concurrency
-- **Lower Memory Usage**: More efficient memory management
-- **Type Safety**: Compile-time type checking
-- **Easier Deployment**: Single binary deployment
 
 ## Contributing
 
@@ -782,7 +770,6 @@ This Go implementation maintains API compatibility with the TypeScript version w
 2. Write tests for new functionality
 3. Update documentation concurrently with code changes
 4. Use the provided Makefile for builds and testing
-5. Ensure backward compatibility with TypeScript API
 
 ## License
 

--- a/cmd/aggregator/main.go
+++ b/cmd/aggregator/main.go
@@ -120,12 +120,12 @@ func main() {
 	trustBaseValidator := service.NewTrustBaseValidator(storageInstance.TrustBaseStorage())
 	for _, tb := range cfg.BFT.TrustBases {
 		if err := trustBaseValidator.Verify(ctx, &tb); err != nil {
-			log.WithComponent("main").Error(fmt.Sprintf("Trust base verification failed"), "error", err.Error())
+			log.WithComponent("main").Error("Trust base verification failed", "error", err.Error())
 			gracefulExit(asyncLogger, 1)
 		}
 		if err := storageInstance.TrustBaseStorage().Store(ctx, &tb); err != nil {
 			if errors.Is(err, interfaces.ErrTrustBaseAlreadyExists) {
-				log.WithComponent("main").Warn(fmt.Sprintf("Trust base already exists, not overwriting it"), "epoch", tb.GetEpoch())
+				log.WithComponent("main").Warn("Trust base already exists, not overwriting it", "epoch", tb.GetEpoch())
 			} else {
 				log.WithComponent("main").Error("Failed to store trust base", "epoch", tb.GetEpoch(), "error", err.Error())
 				gracefulExit(asyncLogger, 1)
@@ -144,6 +144,7 @@ func main() {
 	stateTracker := state.NewSyncStateTracker()
 
 	eventBus := events.NewEventBus(log)
+	startFatalErrorListener(ctx, log, eventBus, stop)
 
 	// Load last committed unicity certificate (can be nil for genesis)
 	var luc *types.UnicityCertificate
@@ -288,6 +289,39 @@ func main() {
 	if err := baseLogger.Close(); err != nil {
 		fmt.Printf("Failed to close file logger: %v\n", err)
 	}
+}
+
+func startFatalErrorListener(ctx context.Context, log *logger.Logger, eventBus *events.EventBus, stop context.CancelFunc) {
+	fatalCh := eventBus.Subscribe(events.TopicFatalError)
+	go func() {
+		defer func() {
+			if err := eventBus.Unsubscribe(events.TopicFatalError, fatalCh); err != nil {
+				log.WithComponent("fatal-listener").Error("Failed to unsubscribe from fatal error topic", "error", err)
+			}
+		}()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case evt := <-fatalCh:
+				source := "unknown"
+				detail := ""
+				switch e := evt.(type) {
+				case events.FatalErrorEvent:
+					source = e.Source
+					detail = e.Error
+				case *events.FatalErrorEvent:
+					source = e.Source
+					detail = e.Error
+				}
+				log.WithComponent("fatal-listener").Error("Fatal error event received, shutting down",
+					"source", source,
+					"error", detail)
+				stop()
+				return
+			}
+		}
+	}()
 }
 
 func startLeaderChangedEventListener(ctx context.Context, log *logger.Logger, cfg *config.Config, roundManager round.Manager, bs *ha.BlockSyncer, eventBus *events.EventBus) error {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -2,10 +2,17 @@ package events
 
 const (
 	TopicLeaderChanged Topic = "leaderChanged"
+	TopicFatalError    Topic = "fatalError"
 )
 
 // LeaderChangedEvent is published when the node becomes a leader
 // or when the node loses leader status and becomes a follower.
 type LeaderChangedEvent struct {
 	IsLeader bool
+}
+
+// FatalErrorEvent signals an unrecoverable error that should trigger shutdown.
+type FatalErrorEvent struct {
+	Source string
+	Error  string
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -186,7 +186,7 @@ func (s *Server) handleHealth(c *gin.Context) {
 	}
 
 	// Return 503 if unhealthy so load balancers can remove from rotation
-	if status.Status == "unhealthy" {
+	if status.Status == api.HealthStatusUnhealthy {
 		c.JSON(http.StatusServiceUnavailable, status)
 		return
 	}

--- a/internal/models/health_status.go
+++ b/internal/models/health_status.go
@@ -14,7 +14,7 @@ type HealthStatus struct {
 // NewHealthStatus creates a new health status
 func NewHealthStatus(role, serverID string, sharding api.Sharding) *HealthStatus {
 	return &HealthStatus{
-		Status:   "ok",
+		Status:   api.HealthStatusOk,
 		Role:     role,
 		ServerID: serverID,
 		Sharding: sharding,

--- a/internal/round/batch_processor.go
+++ b/internal/round/batch_processor.go
@@ -239,11 +239,26 @@ func (rm *RoundManager) pollWithPreCollection(ctx context.Context, rootHash stri
 		maxPreCollect = 10000
 	}
 
+	// Buffer for batching pre-collection
+	pendingCommitments := make([]*models.Commitment, 0, miniBatchSize)
+	flushBatch := func() {
+		if len(pendingCommitments) == 0 {
+			return
+		}
+		if err := rm.addBatchToPreCollection(ctx, pendingCommitments); err != nil {
+			rm.logger.WithContext(ctx).Error("Failed to add batch to pre-collection", "error", err.Error())
+			return // Don't clear - will retry on next flush
+		}
+		preCollectCount += len(pendingCommitments)
+		pendingCommitments = pendingCommitments[:0]
+	}
+
 	pollStart := time.Now()
 
 	for {
 		select {
 		case <-pollingCtx.Done():
+			flushBatch()
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
@@ -253,10 +268,14 @@ func (rm *RoundManager) pollWithPreCollection(ctx context.Context, rootHash stri
 			return nil, fmt.Errorf("timed out waiting for parent shard inclusion proof %s", rootHash)
 
 		case <-ticker.C:
+			flushBatch()
 			request := &api.GetShardProofRequest{ShardID: rm.config.Sharding.Child.ShardID}
 			proof, err := rm.rootClient.GetShardProof(pollingCtx, request)
 			if err != nil {
-				return nil, fmt.Errorf("failed to fetch parent shard inclusion proof: %w", err)
+				rm.logger.WithContext(ctx).Warn("Failed to fetch parent shard inclusion proof, retrying",
+					"rootHash", rootHash,
+					"error", err.Error())
+				continue
 			}
 			if proof == nil || !proof.IsValid(rootHash) {
 				continue
@@ -264,20 +283,52 @@ func (rm *RoundManager) pollWithPreCollection(ctx context.Context, rootHash stri
 			return proof, nil
 
 		case commitment := <-rm.commitmentStream:
-			if preCollectCount < maxPreCollect {
-				if err := rm.addToPreCollection(ctx, commitment); err != nil {
-					rm.logger.WithContext(ctx).Error("Failed to add commitment to pre-collection",
-						"requestID", commitment.RequestID.String(),
-						"error", err.Error())
-				} else {
-					preCollectCount++
+			if preCollectCount+len(pendingCommitments) < maxPreCollect {
+				pendingCommitments = append(pendingCommitments, commitment)
+				if len(pendingCommitments) >= miniBatchSize {
+					flushBatch()
 				}
 			}
 		}
 	}
 }
 
+// addToPreCollection adds a single commitment (convenience wrapper for tests)
 func (rm *RoundManager) addToPreCollection(ctx context.Context, commitment *models.Commitment) error {
+	return rm.addBatchToPreCollection(ctx, []*models.Commitment{commitment})
+}
+
+func (rm *RoundManager) addBatchToPreCollection(ctx context.Context, commitments []*models.Commitment) error {
+	if len(commitments) == 0 {
+		return nil
+	}
+
+	leaves := make([]*smt.Leaf, 0, len(commitments))
+	validCommitments := make([]*models.Commitment, 0, len(commitments))
+
+	for _, commitment := range commitments {
+		path, err := commitment.RequestID.GetPath()
+		if err != nil {
+			rm.logger.WithContext(ctx).Error("Failed to get path for commitment",
+				"requestID", commitment.RequestID.String(), "error", err.Error())
+			continue
+		}
+
+		leafValue, err := commitment.CreateLeafValue()
+		if err != nil {
+			rm.logger.WithContext(ctx).Error("Failed to create leaf value",
+				"requestID", commitment.RequestID.String(), "error", err.Error())
+			continue
+		}
+
+		leaves = append(leaves, &smt.Leaf{Path: path, Value: leafValue})
+		validCommitments = append(validCommitments, commitment)
+	}
+
+	if len(leaves) == 0 {
+		return nil
+	}
+
 	rm.preCollectionMutex.Lock()
 	defer rm.preCollectionMutex.Unlock()
 
@@ -285,29 +336,52 @@ func (rm *RoundManager) addToPreCollection(ctx context.Context, commitment *mode
 		return fmt.Errorf("pre-collection snapshot not initialized")
 	}
 
-	path, err := commitment.RequestID.GetPath()
-	if err != nil {
-		return fmt.Errorf("failed to get path for commitment: %w", err)
+	if _, err := rm.preCollectionSnapshot.AddLeaves(leaves); err != nil {
+		// Fall back to adding leaves one by one, skipping bad ones
+		rm.addLeavesOneByOne(ctx, leaves, validCommitments)
+		return nil
 	}
 
-	leafValue, err := commitment.CreateLeafValue()
-	if err != nil {
-		return fmt.Errorf("failed to create leaf value: %w", err)
-	}
-
-	leaf := &smt.Leaf{
-		Path:  path,
-		Value: leafValue,
-	}
-
-	if _, err := rm.preCollectionSnapshot.AddLeaves([]*smt.Leaf{leaf}); err != nil {
-		return fmt.Errorf("failed to add leaf to pre-collection snapshot: %w", err)
-	}
-
-	rm.preCollectedCommitments = append(rm.preCollectedCommitments, commitment)
-	rm.preCollectedLeaves = append(rm.preCollectedLeaves, leaf)
+	rm.preCollectedCommitments = append(rm.preCollectedCommitments, validCommitments...)
+	rm.preCollectedLeaves = append(rm.preCollectedLeaves, leaves...)
 
 	return nil
+}
+
+// addLeavesOneByOne adds leaves individually, skipping any that fail.
+// Must be called with preCollectionMutex held.
+func (rm *RoundManager) addLeavesOneByOne(ctx context.Context, leaves []*smt.Leaf, commitments []*models.Commitment) {
+	var rejected []interfaces.CommitmentAck
+	for i, leaf := range leaves {
+		if err := rm.preCollectionSnapshot.AddLeaf(leaf.Path, leaf.Value); err != nil {
+			rm.logger.WithContext(ctx).Warn("Rejected commitment during pre-collection",
+				"requestID", commitments[i].RequestID.String(),
+				"error", err.Error())
+			rejected = append(rejected, interfaces.CommitmentAck{
+				RequestID: commitments[i].RequestID,
+				StreamID:  commitments[i].StreamID,
+			})
+			continue
+		}
+		rm.preCollectedCommitments = append(rm.preCollectedCommitments, commitments[i])
+		rm.preCollectedLeaves = append(rm.preCollectedLeaves, leaf)
+	}
+
+	if len(rejected) == 0 {
+		return
+	}
+
+	if rm.commitmentQueue == nil {
+		rm.logger.WithContext(ctx).Warn("Commitment queue not configured, rejected commitments not marked processed",
+			"count", len(rejected))
+		return
+	}
+
+	if err := rm.commitmentQueue.MarkProcessed(ctx, rejected); err != nil {
+		rm.logger.WithContext(ctx).Error("Failed to mark rejected commitments as processed",
+			"count", len(rejected),
+			"error", err.Error())
+	}
 }
 
 func (rm *RoundManager) initPreCollection(ctx context.Context) {
@@ -484,6 +558,7 @@ func (rm *RoundManager) FinalizeBlock(ctx context.Context, block *models.Block) 
 	}
 	persistDataTime = time.Since(persistDataStart)
 
+	rm.finalizationMu.Lock()
 	if snapshot != nil {
 		commitSnapshotStart = time.Now()
 		snapshot.Commit(rm.smt)
@@ -491,8 +566,10 @@ func (rm *RoundManager) FinalizeBlock(ctx context.Context, block *models.Block) 
 	}
 
 	if err := rm.storage.BlockStorage().SetFinalized(ctx, block.Index, true); err != nil {
+		rm.finalizationMu.Unlock()
 		return fmt.Errorf("failed to set block as finalized: %w", err)
 	}
+	rm.finalizationMu.Unlock()
 	block.Finalized = true
 
 	if len(ackEntries) > 0 {

--- a/internal/round/factory.go
+++ b/internal/round/factory.go
@@ -23,6 +23,8 @@ type Manager interface {
 	Deactivate(ctx context.Context) error
 	GetSMT() *smt.ThreadSafeSMT
 	CheckParentHealth(ctx context.Context) error
+	// FinalizationReadLock blocks during the SMT commit+finalize window to keep root/block consistent.
+	FinalizationReadLock() func()
 }
 
 // NewManager creates the appropriate round manager based on sharding mode

--- a/internal/round/parent_round_manager.go
+++ b/internal/round/parent_round_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/unicitynetwork/bft-go-base/types"
@@ -58,6 +59,8 @@ type ParentRoundManager struct {
 	// Metrics
 	totalRounds       int64
 	totalShardUpdates int64
+
+	ready atomic.Bool
 }
 
 const parentRoundRetryDelay = 1 * time.Second
@@ -384,9 +387,20 @@ func (prm *ParentRoundManager) GetSMT() *smt.ThreadSafeSMT {
 	return prm.parentSMT
 }
 
+// IsReady reports whether the parent round manager is ready to accept shard roots.
+func (prm *ParentRoundManager) IsReady() bool {
+	return prm.ready.Load()
+}
+
+// FinalizationReadLock is a no-op for parent mode (no SMT/block finalize race).
+func (prm *ParentRoundManager) FinalizationReadLock() func() {
+	return func() {}
+}
+
 // Activate starts active round processing (called when node becomes leader in HA mode)
 func (prm *ParentRoundManager) Activate(ctx context.Context) error {
 	prm.logger.WithContext(ctx).Info("Activating parent round manager")
+	prm.ready.Store(false)
 
 	// Reconstruct parent SMT from current shard states in storage
 	// This ensures the follower-turned-leader has the latest state
@@ -430,12 +444,14 @@ func (prm *ParentRoundManager) Activate(ctx context.Context) error {
 	prm.logger.WithContext(ctx).Info("Parent round manager activated successfully",
 		"initialRound", nextRoundNumber.String())
 
+	prm.ready.Store(true)
 	return nil
 }
 
 // Deactivate stops active round processing (called when node loses leadership in HA mode)
 func (prm *ParentRoundManager) Deactivate(ctx context.Context) error {
 	prm.logger.WithContext(ctx).Info("Deactivating parent round manager")
+	prm.ready.Store(false)
 
 	// Stop BFT client
 	prm.bftClient.Stop()
@@ -498,29 +514,40 @@ func (prm *ParentRoundManager) FinalizeBlock(ctx context.Context, block *models.
 	}
 	prm.roundMutex.RUnlock()
 
+	// Build SMT nodes from shard updates (outside transaction)
+	var smtNodes []*models.SmtNode
 	if len(processedShardUpdates) > 0 {
-		smtNodes := make([]*models.SmtNode, 0, len(processedShardUpdates))
+		smtNodes = make([]*models.SmtNode, 0, len(processedShardUpdates))
 		for _, update := range processedShardUpdates {
 			bytes := make([]byte, 4)
 			binary.BigEndian.PutUint32(bytes, uint32(update.ShardID))
 			smtNode := models.NewSmtNode(api.NewHexBytes(bytes), update.RootHash)
 			smtNodes = append(smtNodes, smtNode)
 		}
+	}
 
-		if err := prm.storage.SmtStorage().UpsertBatch(ctx, smtNodes); err != nil {
-			return fmt.Errorf("failed to upsert shard states: %w", err)
+	// Use transaction to atomically store shard states and block together
+	// This prevents root hash mismatch if crash occurs between operations
+	block.Finalized = true
+	if err := prm.storage.WithTransaction(ctx, func(txCtx context.Context) error {
+		if len(smtNodes) > 0 {
+			if err := prm.storage.SmtStorage().UpsertBatch(txCtx, smtNodes); err != nil {
+				return fmt.Errorf("failed to upsert shard states: %w", err)
+			}
 		}
+		if err := prm.storage.BlockStorage().Store(txCtx, block); err != nil {
+			return fmt.Errorf("failed to store parent block: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to finalize parent block transaction: %w", err)
+	}
 
+	if len(smtNodes) > 0 {
 		prm.logger.WithContext(ctx).Info("Updated current shard states in storage",
 			"blockNumber", block.Index.String(),
 			"shardCount", len(processedShardUpdates),
 			"shardIDs", getShardIDs(processedShardUpdates))
-	}
-
-	// For parent mode, we store everything synchronously, so the block is finalized immediately
-	block.Finalized = true
-	if err := prm.storage.BlockStorage().Store(ctx, block); err != nil {
-		return fmt.Errorf("failed to store parent block: %w", err)
 	}
 
 	if snapshot != nil {
@@ -596,6 +623,22 @@ func (prm *ParentRoundManager) reconstructParentSMT(ctx context.Context) error {
 		prm.logger.WithContext(ctx).Info("Successfully reconstructed parent SMT",
 			"leafCount", len(leaves),
 			"rootHash", prm.parentSMT.GetRootHash())
+	}
+
+	// Verify reconstructed root hash matches latest block (safety check)
+	latestBlock, err := prm.storage.BlockStorage().GetLatest(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get latest block for verification: %w", err)
+	}
+	if latestBlock != nil {
+		reconstructedHash := prm.parentSMT.GetRootHash()
+		expectedHash := latestBlock.RootHash.String()
+		if reconstructedHash != expectedHash {
+			return fmt.Errorf("parent SMT reconstruction failed: root hash mismatch (got %s, expected %s)", reconstructedHash, expectedHash)
+		}
+		prm.logger.WithContext(ctx).Info("Parent SMT root hash verification passed",
+			"rootHash", reconstructedHash,
+			"blockNumber", latestBlock.Index.String())
 	}
 
 	return nil

--- a/internal/round/round_manager_test.go
+++ b/internal/round/round_manager_test.go
@@ -21,10 +21,6 @@ import (
 
 // test the good case where blocks are created and stored successfully
 func TestParentShardIntegration_GoodCase(t *testing.T) {
-	// Override osExit to prevent actual process termination during test cleanup
-	restoreExit := SetExitFunc(func(code int) {})
-	defer restoreExit()
-
 	// setup dependencies
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -64,15 +64,9 @@ func (suite *AggregatorTestSuite) TearDownTest() {
 func setupMongoDBAndAggregator(t *testing.T, ctx context.Context) (string, func()) {
 	var mongoContainer *mongodb.MongoDBContainer
 
-	// Override osExit to prevent test process termination during teardown
-	restoreExit := round.SetExitFunc(func(code int) {
-		t.Logf("os.Exit(%d) called but suppressed in test", code)
-	})
-
 	// Ensure cleanup happens even if setup fails
 	defer func() {
 		if r := recover(); r != nil {
-			restoreExit()
 			if mongoContainer != nil {
 				mongoContainer.Terminate(context.Background())
 			}
@@ -178,9 +172,6 @@ func setupMongoDBAndAggregator(t *testing.T, ctx context.Context) (string, func(
 
 	// Return the server address and cleanup function
 	return serverAddr, func() {
-		// Restore the original exit function at the end
-		defer restoreExit()
-
 		// Create shutdown context
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -522,6 +513,7 @@ func (s *stubRoundManager) Deactivate(context.Context) error {
 }
 func (s *stubRoundManager) GetSMT() *smt.ThreadSafeSMT              { return s.smt }
 func (s *stubRoundManager) CheckParentHealth(context.Context) error { return nil }
+func (s *stubRoundManager) FinalizationReadLock() func()            { return func() {} }
 
 func newAggregatorServiceForTest(t *testing.T, shardingCfg config.ShardingConfig, baseTree *smt.SparseMerkleTree) *AggregatorService {
 	t.Helper()

--- a/internal/sharding/root_aggregator_client.go
+++ b/internal/sharding/root_aggregator_client.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
@@ -42,9 +44,21 @@ type (
 )
 
 func NewRootAggregatorClient(rpcURL string) *RootAggregatorClient {
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 5 * time.Second,
+		}).DialContext,
+		ResponseHeaderTimeout: 10 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
+		MaxIdleConnsPerHost:   10,
+	}
 	return &RootAggregatorClient{
 		rpcURL:     rpcURL,
-		httpClient: &http.Client{},
+		httpClient: &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: transport,
+		},
 		requestIDC: new(atomic.Int64),
 	}
 }

--- a/internal/smt/smt_memory_benchmark_test.go
+++ b/internal/smt/smt_memory_benchmark_test.go
@@ -1,0 +1,299 @@
+package smt
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"runtime"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+
+	"github.com/unicitynetwork/aggregator-go/internal/models"
+	"github.com/unicitynetwork/aggregator-go/internal/signing"
+	"github.com/unicitynetwork/aggregator-go/internal/testutil"
+	"github.com/unicitynetwork/aggregator-go/pkg/api"
+)
+
+// generateCommitment creates a valid commitment for benchmarking without testing.T dependency
+func generateCommitment(index int) (*models.Commitment, error) {
+	privateKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+	publicKeyBytes := privateKey.PubKey().SerializeCompressed()
+
+	stateData := make([]byte, 32)
+	baseData := fmt.Sprintf("bench_%d", index)
+	copy(stateData, baseData)
+	if len(baseData) < 32 {
+		_, err = rand.Read(stateData[len(baseData):])
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate random state data: %w", err)
+		}
+	}
+	stateHashImprint := signing.CreateDataHashImprint(stateData)
+
+	requestID, err := api.CreateRequestID(publicKeyBytes, stateHashImprint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request ID: %w", err)
+	}
+
+	transactionData := make([]byte, 32)
+	txPrefix := fmt.Sprintf("tx_bench_%d", index)
+	copy(transactionData, txPrefix)
+	if len(txPrefix) < 32 {
+		_, err = rand.Read(transactionData[len(txPrefix):])
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate random transaction data: %w", err)
+		}
+	}
+	transactionHashImprint := signing.CreateDataHashImprint(transactionData)
+
+	transactionHashBytes, err := transactionHashImprint.DataBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract transaction hash: %w", err)
+	}
+
+	signingService := signing.NewSigningService()
+	signatureBytes, err := signingService.SignHash(transactionHashBytes, privateKey.Serialize())
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign transaction: %w", err)
+	}
+
+	authenticator := models.Authenticator{
+		Algorithm: "secp256k1",
+		PublicKey: publicKeyBytes,
+		Signature: signatureBytes,
+		StateHash: stateHashImprint,
+	}
+
+	return models.NewCommitment(requestID, transactionHashImprint, authenticator), nil
+}
+
+// BenchmarkSMTMemoryUsageRealistic measures actual memory usage with realistic commitments
+func BenchmarkSMTMemoryUsageRealistic(b *testing.B) {
+	sizes := []int{10_000, 100_000, 500_000, 1_000_000, 2_000_000}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("leaves_%d", size), func(b *testing.B) {
+			// Force GC and get baseline memory
+			runtime.GC()
+			var memBefore runtime.MemStats
+			runtime.ReadMemStats(&memBefore)
+
+			// Create SMT with realistic key length (16 bits shard prefix + 256 bits hash)
+			smtTree := NewSparseMerkleTree(api.SHA256, 16+256)
+
+			// Generate realistic commitments and add as leaves
+			leaves := make([]*Leaf, size)
+			for i := 0; i < size; i++ {
+				commitment, err := generateCommitment(i)
+				if err != nil {
+					b.Fatalf("Failed to generate commitment: %v", err)
+				}
+
+				path, err := commitment.RequestID.GetPath()
+				if err != nil {
+					b.Fatalf("Failed to get path: %v", err)
+				}
+
+				leafValue, err := commitment.CreateLeafValue()
+				if err != nil {
+					b.Fatalf("Failed to create leaf value: %v", err)
+				}
+
+				leaves[i] = &Leaf{Path: path, Value: leafValue}
+
+				// Progress logging for large runs
+				if (i+1)%100_000 == 0 {
+					b.Logf("Generated %d/%d leaves", i+1, size)
+				}
+			}
+
+			b.ResetTimer()
+
+			// Add all leaves to SMT
+			err := smtTree.AddLeaves(leaves)
+			if err != nil {
+				b.Fatalf("Failed to add leaves: %v", err)
+			}
+
+			// Calculate root hash (triggers hash computation)
+			_ = smtTree.GetRootHash()
+
+			b.StopTimer()
+
+			// Force GC and measure memory after
+			runtime.GC()
+			var memAfter runtime.MemStats
+			runtime.ReadMemStats(&memAfter)
+
+			// Calculate memory used by SMT
+			memUsedBytes := memAfter.Alloc - memBefore.Alloc
+			memUsedMB := float64(memUsedBytes) / 1024 / 1024
+
+			b.ReportMetric(float64(memUsedBytes), "bytes")
+			b.ReportMetric(memUsedMB, "MB")
+			b.ReportMetric(float64(memUsedBytes)/float64(size), "bytes/leaf")
+
+			b.Logf("SMT with %d leaves: %.2f MB total, %.2f bytes/leaf",
+				size, memUsedMB, float64(memUsedBytes)/float64(size))
+		})
+	}
+}
+
+// TestSMTMemoryMeasurement is a test (not benchmark) for precise memory measurement
+// Run with: go test -v -run TestSMTMemoryMeasurement -timeout 30m
+func TestSMTMemoryMeasurement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping memory measurement in short mode")
+	}
+
+	sizes := []int{10_000, 100_000, 500_000, 1_000_000}
+
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("leaves_%d", size), func(t *testing.T) {
+			// Step 1: Generate leaves first (this allocates memory for commitments)
+			t.Logf("Generating %d commitments...", size)
+			leaves := make([]*Leaf, size)
+			for i := 0; i < size; i++ {
+				commitment := testutil.CreateTestCommitment(t, fmt.Sprintf("mem_test_%d", i))
+
+				path, err := commitment.RequestID.GetPath()
+				if err != nil {
+					t.Fatalf("Failed to get path: %v", err)
+				}
+
+				leafValue, err := commitment.CreateLeafValue()
+				if err != nil {
+					t.Fatalf("Failed to create leaf value: %v", err)
+				}
+
+				leaves[i] = &Leaf{Path: path, Value: leafValue}
+
+				if (i+1)%50_000 == 0 {
+					t.Logf("Generated %d/%d leaves", i+1, size)
+				}
+			}
+
+			// Step 2: Force GC to get accurate baseline AFTER commitment generation
+			runtime.GC()
+			runtime.GC()
+			var memBefore runtime.MemStats
+			runtime.ReadMemStats(&memBefore)
+
+			// Step 3: Create SMT and add leaves
+			smtTree := NewSparseMerkleTree(api.SHA256, 16+256)
+			t.Logf("Adding %d leaves to SMT...", size)
+			err := smtTree.AddLeaves(leaves)
+			if err != nil {
+				t.Fatalf("Failed to add leaves: %v", err)
+			}
+
+			// Calculate root hash (materializes cached hashes)
+			rootHash := smtTree.GetRootHashHex()
+			t.Logf("Root hash: %s", rootHash[:16]+"...")
+
+			// Step 4: Measure memory BEFORE clearing leaves (SMT still holds refs)
+			var memAfterSMT runtime.MemStats
+			runtime.ReadMemStats(&memAfterSMT)
+
+			smtAllocBytes := memAfterSMT.HeapAlloc - memBefore.HeapAlloc
+			smtAllocMB := float64(smtAllocBytes) / 1024 / 1024
+
+			// Step 5: Now clear leaves and force GC to see SMT-only memory
+			leaves = nil
+			runtime.GC()
+			runtime.GC()
+
+			var memFinal runtime.MemStats
+			runtime.ReadMemStats(&memFinal)
+
+			// This is the memory held by SMT alone (after leaves slice is GC'd)
+			finalHeapMB := float64(memFinal.HeapAlloc) / 1024 / 1024
+
+			t.Logf("\n=== SMT Memory Usage for %d leaves ===", size)
+			t.Logf("SMT allocation:  %.2f MB (%.2f bytes/leaf)", smtAllocMB, float64(smtAllocBytes)/float64(size))
+			t.Logf("Final heap:      %.2f MB", finalHeapMB)
+			t.Logf("TotalAlloc:      %.2f MB (cumulative)", float64(memFinal.TotalAlloc)/1024/1024)
+			t.Logf("Sys (from OS):   %.2f MB", float64(memFinal.Sys)/1024/1024)
+			t.Logf("==========================================\n")
+
+			// Keep SMT alive to prevent optimization
+			runtime.KeepAlive(smtTree)
+		})
+	}
+}
+
+// BenchmarkSMTOperationsWithLoad benchmarks operations with a pre-populated SMT
+func BenchmarkSMTOperationsWithLoad(b *testing.B) {
+	// Pre-populate with 100k leaves
+	const preloadSize = 100_000
+
+	smtTree := NewSparseMerkleTree(api.SHA256, 16+256)
+	leaves := make([]*Leaf, preloadSize)
+	paths := make([]*big.Int, preloadSize)
+
+	b.Logf("Pre-populating SMT with %d leaves...", preloadSize)
+	for i := 0; i < preloadSize; i++ {
+		commitment, err := generateCommitment(i)
+		if err != nil {
+			b.Fatalf("Failed to generate commitment: %v", err)
+		}
+
+		path, _ := commitment.RequestID.GetPath()
+		leafValue, _ := commitment.CreateLeafValue()
+
+		leaves[i] = &Leaf{Path: path, Value: leafValue}
+		paths[i] = path
+	}
+
+	err := smtTree.AddLeaves(leaves)
+	if err != nil {
+		b.Fatalf("Failed to preload SMT: %v", err)
+	}
+
+	// Force hash computation
+	_ = smtTree.GetRootHash()
+	b.Logf("SMT preloaded, running benchmarks...")
+
+	b.Run("GetPath_100k_leaves", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			path := paths[i%preloadSize]
+			_, err := smtTree.GetPath(path)
+			if err != nil {
+				b.Fatalf("GetPath failed: %v", err)
+			}
+		}
+	})
+
+	b.Run("AddLeaf_to_100k_tree", func(b *testing.B) {
+		// Create a snapshot for each add to avoid modifying the base tree
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			snapshot := smtTree.CreateSnapshot()
+			commitment, err := generateCommitment(preloadSize + i)
+			if err != nil {
+				b.Fatalf("Failed to generate commitment: %v", err)
+			}
+			path, _ := commitment.RequestID.GetPath()
+			leafValue, _ := commitment.CreateLeafValue()
+			b.StartTimer()
+
+			err = snapshot.AddLeaf(path, leafValue)
+			if err != nil && err != ErrDuplicateLeaf {
+				b.Fatalf("AddLeaf failed: %v", err)
+			}
+		}
+	})
+
+	b.Run("GetRootHash_100k_leaves", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = smtTree.GetRootHash()
+		}
+	})
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -273,6 +273,14 @@ const (
 	ShardRootStatusInvalidRootHash = "INVALID_ROOT_HASH"
 	ShardRootStatusInternalError   = "INTERNAL_ERROR"
 	ShardRootStatusNotLeader       = "NOT_LEADER"
+	ShardRootStatusNotReady        = "NOT_READY"
+)
+
+// Health status values returned by the health endpoint.
+const (
+	HealthStatusOk        = "ok"
+	HealthStatusUnhealthy = "unhealthy"
+	HealthStatusDegraded  = "degraded"
 )
 
 // SubmitShardRootRequest represents the submit_shard_root JSON-RPC request
@@ -309,7 +317,7 @@ type HealthStatus struct {
 // NewHealthStatus creates a new health status
 func NewHealthStatus(role, serverID string) *HealthStatus {
 	return &HealthStatus{
-		Status:   "ok",
+		Status:   HealthStatusOk,
 		Role:     role,
 		ServerID: serverID,
 		Details:  make(map[string]string),


### PR DESCRIPTION
  - Parent finalize now uses a DB transaction so block + shard states are atomic.
  - Inclusion proofs: parent now finds the latest block matching the proof root instead of just getting latest block
  - Added a short read‑lock around SMT commit+finalize so inclusion proofs don’t observe inconsistent roots.
  - Pre‑collection: added batch insertion for commitments
  - Redis trimming now skips pending/unacked entries and only trims processed commitments
  - Parent /health returns 503 when bft client not initialized
  - use event bus for signaling fatal error and graceful exit