### PR TITLE
Add Redis Sentinel (HA) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,37 @@ The service is configured via environment variables:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `USE_REDIS_FOR_COMMITMENTS` | Use Redis for commitment queue (instead of MongoDB) | `false` |
-| `REDIS_HOST` | Redis server hostname | `localhost` |
-| `REDIS_PORT` | Redis server port | `6379` |
-| `REDIS_PASSWORD` | Redis server password | `` |
+| `REDIS_HOST` | Redis server hostname (single-endpoint mode) | `localhost` |
+| `REDIS_PORT` | Redis server port (single-endpoint mode) | `6379` |
+| `REDIS_PASSWORD` | Redis server password (data nodes) | `` |
 | `REDIS_DB` | Redis database number | `0` |
 | `REDIS_STREAM_NAME` | Redis stream name for commitments (allows multiple shards to share a Redis instance) | `commitments` |
 | `REDIS_FLUSH_INTERVAL` | Interval for flushing pending commitments to Redis | `50ms` |
 | `REDIS_MAX_BATCH_SIZE` | Maximum batch size before forcing flush | `2000` |
+
+#### Redis Sentinel (HA)
+
+Set `REDIS_SENTINEL_ADDRS` to switch the client to Sentinel-backed failover. When set, `REDIS_HOST`/`REDIS_PORT` are ignored and `REDIS_MASTER_NAME` is required.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `REDIS_SENTINEL_ADDRS` | Comma-separated `host:port` list of Sentinel nodes. Empty = single-endpoint mode. | `` |
+| `REDIS_MASTER_NAME` | Sentinel master name to track. Required when `REDIS_SENTINEL_ADDRS` is set. | `` |
+| `REDIS_SENTINEL_PASSWORD` | Password for authenticating to Sentinel nodes. | `` |
+| `REDIS_SENTINEL_USERNAME` | ACL username for authenticating to Sentinel nodes. | `` |
+| `REDIS_ROUTE_BY_LATENCY` | Route read-only commands to the lowest-latency node. | `false` |
+| `REDIS_ROUTE_RANDOMLY` | Route read-only commands to a random master/replica. | `false` |
+| `REDIS_REPLICA_ONLY` | Route all commands to replica read-only nodes. | `false` |
+
+Example:
+
+```bash
+USE_REDIS_FOR_COMMITMENTS=true \
+REDIS_SENTINEL_ADDRS=sentinel-1:26379,sentinel-2:26379,sentinel-3:26379 \
+REDIS_MASTER_NAME=mymaster \
+REDIS_PASSWORD=secret \
+make run
+```
 
 ### BFT Configuration
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,6 @@ Set `REDIS_SENTINEL_ADDRS` to switch the client to Sentinel-backed failover. Whe
 | `REDIS_MASTER_NAME` | Sentinel master name to track. Required when `REDIS_SENTINEL_ADDRS` is set. | `` |
 | `REDIS_SENTINEL_PASSWORD` | Password for authenticating to Sentinel nodes. | `` |
 | `REDIS_SENTINEL_USERNAME` | ACL username for authenticating to Sentinel nodes. | `` |
-| `REDIS_ROUTE_BY_LATENCY` | Route read-only commands to the lowest-latency node. | `false` |
-| `REDIS_ROUTE_RANDOMLY` | Route read-only commands to a random master/replica. | `false` |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ The service is configured via environment variables:
 | `REDIS_PASSWORD` | Redis server password (data nodes) | `` |
 | `REDIS_DB` | Redis database number | `0` |
 | `REDIS_STREAM_NAME` | Redis stream name for commitments (allows multiple shards to share a Redis instance) | `commitments` |
-| `REDIS_FLUSH_INTERVAL` | Interval for flushing pending commitments to Redis | `50ms` |
-| `REDIS_MAX_BATCH_SIZE` | Maximum batch size before forcing flush | `2000` |
+| `REDIS_FLUSH_INTERVAL` | Interval for flushing pending commitments to Redis | `100ms` |
+| `REDIS_MAX_BATCH_SIZE` | Maximum batch size before forcing flush | `5000` |
 
 #### Redis Sentinel (HA)
 
@@ -184,7 +184,6 @@ Set `REDIS_SENTINEL_ADDRS` to switch the client to Sentinel-backed failover. Whe
 | `REDIS_SENTINEL_USERNAME` | ACL username for authenticating to Sentinel nodes. | `` |
 | `REDIS_ROUTE_BY_LATENCY` | Route read-only commands to the lowest-latency node. | `false` |
 | `REDIS_ROUTE_RANDOMLY` | Route read-only commands to a random master/replica. | `false` |
-| `REDIS_REPLICA_ONLY` | Route all commands to replica read-only nodes. | `false` |
 
 Example:
 

--- a/changes.txt
+++ b/changes.txt
@@ -3,10 +3,13 @@ CHANGELOG ENTRY - 04 May 2026 at 17:50 CET
 Add Redis Sentinel (HA) support for the commitment queue (#148).
 
 - Extend RedisConfig with SentinelAddrs, MasterName, SentinelPassword,
-  SentinelUsername, RouteByLatency, RouteRandomly, ReplicaOnly fields
-  driven by REDIS_SENTINEL_ADDRS, REDIS_MASTER_NAME,
-  REDIS_SENTINEL_PASSWORD, REDIS_SENTINEL_USERNAME,
-  REDIS_ROUTE_BY_LATENCY, REDIS_ROUTE_RANDOMLY and REDIS_REPLICA_ONLY.
+  SentinelUsername, RouteByLatency, RouteRandomly fields driven by
+  REDIS_SENTINEL_ADDRS, REDIS_MASTER_NAME, REDIS_SENTINEL_PASSWORD,
+  REDIS_SENTINEL_USERNAME, REDIS_ROUTE_BY_LATENCY and
+  REDIS_ROUTE_RANDOMLY. The ReplicaOnly knob is intentionally not
+  exposed because the commitment queue is write-heavy (XADD/XACK/
+  XReadGroup) and routing all commands to read-only replicas would
+  break it with READONLY errors at runtime.
 - internal/storage/factory.go now branches: if REDIS_SENTINEL_ADDRS is
   non-empty it builds a redis client via NewFailoverClient, otherwise
   falls back to the existing single-endpoint NewClient path. The factory
@@ -14,8 +17,13 @@ Add Redis Sentinel (HA) support for the commitment queue (#148).
   master name, and master name without sentinel addrs (which would
   otherwise silently fall back to single-endpoint mode).
 - The factory now logs the active mode (sentinel/direct) at startup so
-  operators can confirm HA wiring from the logs.
-- README.md documents the new env vars and a usage example.
+  operators can confirm HA wiring from the logs, and it propagates the
+  caller's context.Context through to the initial Redis Ping so
+  upstream timeouts/cancellations are honoured.
+- README.md documents the new env vars and a usage example, and the
+  pre-existing stale defaults for REDIS_FLUSH_INTERVAL and
+  REDIS_MAX_BATCH_SIZE are corrected to match the code (100ms and
+  5000).
 - Adds config-level unit tests covering sentinel env parsing, defaults
   and the new comma-separated string slice helper, plus factory-level
   tests covering both misconfiguration validations.

--- a/changes.txt
+++ b/changes.txt
@@ -9,9 +9,13 @@ Add Redis Sentinel (HA) support for the commitment queue (#148).
   REDIS_ROUTE_BY_LATENCY, REDIS_ROUTE_RANDOMLY and REDIS_REPLICA_ONLY.
 - internal/storage/factory.go now branches: if REDIS_SENTINEL_ADDRS is
   non-empty it builds a redis client via NewFailoverClient, otherwise
-  falls back to the existing single-endpoint NewClient path. A missing
-  REDIS_MASTER_NAME with sentinel addrs set is rejected with a clear
-  error.
+  falls back to the existing single-endpoint NewClient path. The factory
+  rejects both misconfigurations symmetrically: sentinel addrs without
+  master name, and master name without sentinel addrs (which would
+  otherwise silently fall back to single-endpoint mode).
+- The factory now logs the active mode (sentinel/direct) at startup so
+  operators can confirm HA wiring from the logs.
 - README.md documents the new env vars and a usage example.
 - Adds config-level unit tests covering sentinel env parsing, defaults
-  and the new comma-separated string slice helper.
+  and the new comma-separated string slice helper, plus factory-level
+  tests covering both misconfiguration validations.

--- a/changes.txt
+++ b/changes.txt
@@ -1,0 +1,17 @@
+CHANGELOG ENTRY - 04 May 2026 at 17:50 CET
+
+Add Redis Sentinel (HA) support for the commitment queue (#148).
+
+- Extend RedisConfig with SentinelAddrs, MasterName, SentinelPassword,
+  SentinelUsername, RouteByLatency, RouteRandomly, ReplicaOnly fields
+  driven by REDIS_SENTINEL_ADDRS, REDIS_MASTER_NAME,
+  REDIS_SENTINEL_PASSWORD, REDIS_SENTINEL_USERNAME,
+  REDIS_ROUTE_BY_LATENCY, REDIS_ROUTE_RANDOMLY and REDIS_REPLICA_ONLY.
+- internal/storage/factory.go now branches: if REDIS_SENTINEL_ADDRS is
+  non-empty it builds a redis client via NewFailoverClient, otherwise
+  falls back to the existing single-endpoint NewClient path. A missing
+  REDIS_MASTER_NAME with sentinel addrs set is rejected with a clear
+  error.
+- README.md documents the new env vars and a usage example.
+- Adds config-level unit tests covering sentinel env parsing, defaults
+  and the new comma-separated string slice helper.

--- a/changes.txt
+++ b/changes.txt
@@ -2,14 +2,19 @@ CHANGELOG ENTRY - 04 May 2026 at 17:50 CET
 
 Add Redis Sentinel (HA) support for the commitment queue (#148).
 
-- Extend RedisConfig with SentinelAddrs, MasterName, SentinelPassword,
-  SentinelUsername, RouteByLatency, RouteRandomly fields driven by
-  REDIS_SENTINEL_ADDRS, REDIS_MASTER_NAME, REDIS_SENTINEL_PASSWORD,
-  REDIS_SENTINEL_USERNAME, REDIS_ROUTE_BY_LATENCY and
-  REDIS_ROUTE_RANDOMLY. The ReplicaOnly knob is intentionally not
-  exposed because the commitment queue is write-heavy (XADD/XACK/
-  XReadGroup) and routing all commands to read-only replicas would
-  break it with READONLY errors at runtime.
+- Extend RedisConfig with SentinelAddrs, MasterName, SentinelPassword
+  and SentinelUsername fields driven by REDIS_SENTINEL_ADDRS,
+  REDIS_MASTER_NAME, REDIS_SENTINEL_PASSWORD and
+  REDIS_SENTINEL_USERNAME. The ReplicaOnly, RouteByLatency and
+  RouteRandomly knobs are intentionally not exposed: the commitment
+  queue's only read-only command is XPendingExt; routing it to a
+  replica would observe replication-lagged consumer-group state and
+  silently re-deliver already-acked entries. Every other queue op
+  (XADD/XACK/XReadGroup/XAutoClaim) is a write and goes to master
+  unconditionally.
+- Wire the existing REDIS_MIN_IDLE_CONNS / RedisConfig.MinIdleConns
+  field through both client constructors. It was previously loaded
+  from env but never passed to redis options.
 - internal/storage/factory.go now branches: if REDIS_SENTINEL_ADDRS is
   non-empty it builds a redis client via NewFailoverClient, otherwise
   falls back to the existing single-endpoint NewClient path. The factory

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,16 +110,23 @@ type ProcessingConfig struct {
 
 // RedisConfig holds Redis connection configuration
 type RedisConfig struct {
-	Host         string        `mapstructure:"host"`
-	Port         int           `mapstructure:"port"`
-	Password     string        `mapstructure:"password"`
-	DB           int           `mapstructure:"db"`
-	PoolSize     int           `mapstructure:"pool_size"`
-	MinIdleConns int           `mapstructure:"min_idle_conns"`
-	MaxRetries   int           `mapstructure:"max_retries"`
-	DialTimeout  time.Duration `mapstructure:"dial_timeout"`
-	ReadTimeout  time.Duration `mapstructure:"read_timeout"`
-	WriteTimeout time.Duration `mapstructure:"write_timeout"`
+	Host             string        `mapstructure:"host"`
+	Port             int           `mapstructure:"port"`
+	Password         string        `mapstructure:"password"`
+	DB               int           `mapstructure:"db"`
+	PoolSize         int           `mapstructure:"pool_size"`
+	MinIdleConns     int           `mapstructure:"min_idle_conns"`
+	MaxRetries       int           `mapstructure:"max_retries"`
+	DialTimeout      time.Duration `mapstructure:"dial_timeout"`
+	ReadTimeout      time.Duration `mapstructure:"read_timeout"`
+	WriteTimeout     time.Duration `mapstructure:"write_timeout"`
+	SentinelAddrs    []string      `mapstructure:"sentinel_addrs"`
+	MasterName       string        `mapstructure:"master_name"`
+	SentinelPassword string        `mapstructure:"sentinel_password"`
+	SentinelUsername string        `mapstructure:"sentinel_username"`
+	RouteByLatency   bool          `mapstructure:"route_by_latency"`
+	RouteRandomly    bool          `mapstructure:"route_randomly"`
+	ReplicaOnly      bool          `mapstructure:"replica_only"`
 }
 
 // StorageConfig holds storage layer configuration
@@ -322,16 +329,23 @@ func Load() (*Config, error) {
 			MaxCommitmentsPerRound: getEnvIntOrDefault("MAX_COMMITMENTS_PER_ROUND", 10000), // Default 10k to keep rounds under 2s
 		},
 		Redis: RedisConfig{
-			Host:         getEnvOrDefault("REDIS_HOST", "localhost"),
-			Port:         getEnvIntOrDefault("REDIS_PORT", 6379),
-			Password:     getEnvOrDefault("REDIS_PASSWORD", ""),
-			DB:           getEnvIntOrDefault("REDIS_DB", 0),
-			PoolSize:     getEnvIntOrDefault("REDIS_POOL_SIZE", 10),
-			MinIdleConns: getEnvIntOrDefault("REDIS_MIN_IDLE_CONNS", 2),
-			MaxRetries:   getEnvIntOrDefault("REDIS_MAX_RETRIES", 3),
-			DialTimeout:  getEnvDurationOrDefault("REDIS_DIAL_TIMEOUT", "5s"),
-			ReadTimeout:  getEnvDurationOrDefault("REDIS_READ_TIMEOUT", "3s"),
-			WriteTimeout: getEnvDurationOrDefault("REDIS_WRITE_TIMEOUT", "3s"),
+			Host:             getEnvOrDefault("REDIS_HOST", "localhost"),
+			Port:             getEnvIntOrDefault("REDIS_PORT", 6379),
+			Password:         getEnvOrDefault("REDIS_PASSWORD", ""),
+			DB:               getEnvIntOrDefault("REDIS_DB", 0),
+			PoolSize:         getEnvIntOrDefault("REDIS_POOL_SIZE", 10),
+			MinIdleConns:     getEnvIntOrDefault("REDIS_MIN_IDLE_CONNS", 2),
+			MaxRetries:       getEnvIntOrDefault("REDIS_MAX_RETRIES", 3),
+			DialTimeout:      getEnvDurationOrDefault("REDIS_DIAL_TIMEOUT", "5s"),
+			ReadTimeout:      getEnvDurationOrDefault("REDIS_READ_TIMEOUT", "3s"),
+			WriteTimeout:     getEnvDurationOrDefault("REDIS_WRITE_TIMEOUT", "3s"),
+			SentinelAddrs:    getEnvStringSliceOrDefault("REDIS_SENTINEL_ADDRS", nil),
+			MasterName:       getEnvOrDefault("REDIS_MASTER_NAME", ""),
+			SentinelPassword: getEnvOrDefault("REDIS_SENTINEL_PASSWORD", ""),
+			SentinelUsername: getEnvOrDefault("REDIS_SENTINEL_USERNAME", ""),
+			RouteByLatency:   getEnvBoolOrDefault("REDIS_ROUTE_BY_LATENCY", false),
+			RouteRandomly:    getEnvBoolOrDefault("REDIS_ROUTE_RANDOMLY", false),
+			ReplicaOnly:      getEnvBoolOrDefault("REDIS_REPLICA_ONLY", false),
 		},
 		Storage: StorageConfig{
 			UseRedisForCommitments: getEnvBoolOrDefault("USE_REDIS_FOR_COMMITMENTS", false),
@@ -512,6 +526,25 @@ func getEnvDurationOrDefault(key string, defaultValue string) time.Duration {
 	}
 	duration, _ := time.ParseDuration(defaultValue)
 	return duration
+}
+
+func getEnvStringSliceOrDefault(key string, defaultValue []string) []string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return defaultValue
+	}
+	return result
 }
 
 func generateServerID() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,7 +126,6 @@ type RedisConfig struct {
 	SentinelUsername string        `mapstructure:"sentinel_username"`
 	RouteByLatency   bool          `mapstructure:"route_by_latency"`
 	RouteRandomly    bool          `mapstructure:"route_randomly"`
-	ReplicaOnly      bool          `mapstructure:"replica_only"`
 }
 
 // StorageConfig holds storage layer configuration
@@ -345,7 +344,6 @@ func Load() (*Config, error) {
 			SentinelUsername: getEnvOrDefault("REDIS_SENTINEL_USERNAME", ""),
 			RouteByLatency:   getEnvBoolOrDefault("REDIS_ROUTE_BY_LATENCY", false),
 			RouteRandomly:    getEnvBoolOrDefault("REDIS_ROUTE_RANDOMLY", false),
-			ReplicaOnly:      getEnvBoolOrDefault("REDIS_REPLICA_ONLY", false),
 		},
 		Storage: StorageConfig{
 			UseRedisForCommitments: getEnvBoolOrDefault("USE_REDIS_FOR_COMMITMENTS", false),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,8 +124,6 @@ type RedisConfig struct {
 	MasterName       string        `mapstructure:"master_name"`
 	SentinelPassword string        `mapstructure:"sentinel_password"`
 	SentinelUsername string        `mapstructure:"sentinel_username"`
-	RouteByLatency   bool          `mapstructure:"route_by_latency"`
-	RouteRandomly    bool          `mapstructure:"route_randomly"`
 }
 
 // StorageConfig holds storage layer configuration
@@ -342,8 +340,6 @@ func Load() (*Config, error) {
 			MasterName:       getEnvOrDefault("REDIS_MASTER_NAME", ""),
 			SentinelPassword: getEnvOrDefault("REDIS_SENTINEL_PASSWORD", ""),
 			SentinelUsername: getEnvOrDefault("REDIS_SENTINEL_USERNAME", ""),
-			RouteByLatency:   getEnvBoolOrDefault("REDIS_ROUTE_BY_LATENCY", false),
-			RouteRandomly:    getEnvBoolOrDefault("REDIS_ROUTE_RANDOMLY", false),
 		},
 		Storage: StorageConfig{
 			UseRedisForCommitments: getEnvBoolOrDefault("USE_REDIS_FOR_COMMITMENTS", false),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,8 +11,6 @@ func TestRedisSentinelEnvParsing(t *testing.T) {
 	t.Setenv("REDIS_SENTINEL_PASSWORD", "sentpass")
 	t.Setenv("REDIS_SENTINEL_USERNAME", "sentuser")
 	t.Setenv("REDIS_PASSWORD", "datapass")
-	t.Setenv("REDIS_ROUTE_BY_LATENCY", "true")
-	t.Setenv("REDIS_ROUTE_RANDOMLY", "true")
 
 	t.Setenv("BFT_ENABLED", "false")
 	t.Setenv("DISABLE_HIGH_AVAILABILITY", "true")
@@ -38,12 +36,6 @@ func TestRedisSentinelEnvParsing(t *testing.T) {
 	if cfg.Redis.Password != "datapass" {
 		t.Errorf("Password = %q, want %q", cfg.Redis.Password, "datapass")
 	}
-	if !cfg.Redis.RouteByLatency {
-		t.Errorf("RouteByLatency = false, want true")
-	}
-	if !cfg.Redis.RouteRandomly {
-		t.Errorf("RouteRandomly = false, want true")
-	}
 }
 
 func TestRedisSentinelDefaults(t *testing.T) {
@@ -60,10 +52,6 @@ func TestRedisSentinelDefaults(t *testing.T) {
 	}
 	if cfg.Redis.MasterName != "" {
 		t.Errorf("MasterName default = %q, want empty", cfg.Redis.MasterName)
-	}
-	if cfg.Redis.RouteByLatency || cfg.Redis.RouteRandomly {
-		t.Errorf("routing flags should default to false; got latency=%v randomly=%v",
-			cfg.Redis.RouteByLatency, cfg.Redis.RouteRandomly)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,7 +13,6 @@ func TestRedisSentinelEnvParsing(t *testing.T) {
 	t.Setenv("REDIS_PASSWORD", "datapass")
 	t.Setenv("REDIS_ROUTE_BY_LATENCY", "true")
 	t.Setenv("REDIS_ROUTE_RANDOMLY", "true")
-	t.Setenv("REDIS_REPLICA_ONLY", "true")
 
 	t.Setenv("BFT_ENABLED", "false")
 	t.Setenv("DISABLE_HIGH_AVAILABILITY", "true")
@@ -45,9 +44,6 @@ func TestRedisSentinelEnvParsing(t *testing.T) {
 	if !cfg.Redis.RouteRandomly {
 		t.Errorf("RouteRandomly = false, want true")
 	}
-	if !cfg.Redis.ReplicaOnly {
-		t.Errorf("ReplicaOnly = false, want true")
-	}
 }
 
 func TestRedisSentinelDefaults(t *testing.T) {
@@ -65,9 +61,9 @@ func TestRedisSentinelDefaults(t *testing.T) {
 	if cfg.Redis.MasterName != "" {
 		t.Errorf("MasterName default = %q, want empty", cfg.Redis.MasterName)
 	}
-	if cfg.Redis.RouteByLatency || cfg.Redis.RouteRandomly || cfg.Redis.ReplicaOnly {
-		t.Errorf("routing flags should default to false; got latency=%v randomly=%v replica=%v",
-			cfg.Redis.RouteByLatency, cfg.Redis.RouteRandomly, cfg.Redis.ReplicaOnly)
+	if cfg.Redis.RouteByLatency || cfg.Redis.RouteRandomly {
+		t.Errorf("routing flags should default to false; got latency=%v randomly=%v",
+			cfg.Redis.RouteByLatency, cfg.Redis.RouteRandomly)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRedisSentinelEnvParsing(t *testing.T) {
+	t.Setenv("REDIS_SENTINEL_ADDRS", "sentinel-1:26379, sentinel-2:26379 ,sentinel-3:26379")
+	t.Setenv("REDIS_MASTER_NAME", "mymaster")
+	t.Setenv("REDIS_SENTINEL_PASSWORD", "sentpass")
+	t.Setenv("REDIS_SENTINEL_USERNAME", "sentuser")
+	t.Setenv("REDIS_PASSWORD", "datapass")
+	t.Setenv("REDIS_ROUTE_BY_LATENCY", "true")
+	t.Setenv("REDIS_ROUTE_RANDOMLY", "true")
+	t.Setenv("REDIS_REPLICA_ONLY", "true")
+
+	t.Setenv("BFT_ENABLED", "false")
+	t.Setenv("DISABLE_HIGH_AVAILABILITY", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	wantAddrs := []string{"sentinel-1:26379", "sentinel-2:26379", "sentinel-3:26379"}
+	if !reflect.DeepEqual(cfg.Redis.SentinelAddrs, wantAddrs) {
+		t.Errorf("SentinelAddrs = %v, want %v", cfg.Redis.SentinelAddrs, wantAddrs)
+	}
+	if cfg.Redis.MasterName != "mymaster" {
+		t.Errorf("MasterName = %q, want %q", cfg.Redis.MasterName, "mymaster")
+	}
+	if cfg.Redis.SentinelPassword != "sentpass" {
+		t.Errorf("SentinelPassword = %q, want %q", cfg.Redis.SentinelPassword, "sentpass")
+	}
+	if cfg.Redis.SentinelUsername != "sentuser" {
+		t.Errorf("SentinelUsername = %q, want %q", cfg.Redis.SentinelUsername, "sentuser")
+	}
+	if cfg.Redis.Password != "datapass" {
+		t.Errorf("Password = %q, want %q", cfg.Redis.Password, "datapass")
+	}
+	if !cfg.Redis.RouteByLatency {
+		t.Errorf("RouteByLatency = false, want true")
+	}
+	if !cfg.Redis.RouteRandomly {
+		t.Errorf("RouteRandomly = false, want true")
+	}
+	if !cfg.Redis.ReplicaOnly {
+		t.Errorf("ReplicaOnly = false, want true")
+	}
+}
+
+func TestRedisSentinelDefaults(t *testing.T) {
+	t.Setenv("BFT_ENABLED", "false")
+	t.Setenv("DISABLE_HIGH_AVAILABILITY", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if len(cfg.Redis.SentinelAddrs) != 0 {
+		t.Errorf("SentinelAddrs default = %v, want empty", cfg.Redis.SentinelAddrs)
+	}
+	if cfg.Redis.MasterName != "" {
+		t.Errorf("MasterName default = %q, want empty", cfg.Redis.MasterName)
+	}
+	if cfg.Redis.RouteByLatency || cfg.Redis.RouteRandomly || cfg.Redis.ReplicaOnly {
+		t.Errorf("routing flags should default to false; got latency=%v randomly=%v replica=%v",
+			cfg.Redis.RouteByLatency, cfg.Redis.RouteRandomly, cfg.Redis.ReplicaOnly)
+	}
+}
+
+func TestGetEnvStringSliceOrDefault(t *testing.T) {
+	t.Run("unset returns default", func(t *testing.T) {
+		def := []string{"a", "b"}
+		got := getEnvStringSliceOrDefault("UNICITY_TEST_UNSET_VAR", def)
+		if !reflect.DeepEqual(got, def) {
+			t.Errorf("got %v, want %v", got, def)
+		}
+	})
+
+	t.Run("trims and splits", func(t *testing.T) {
+		t.Setenv("UNICITY_TEST_SLICE", " a , b,c ,, d ")
+		got := getEnvStringSliceOrDefault("UNICITY_TEST_SLICE", nil)
+		want := []string{"a", "b", "c", "d"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("only commas returns default", func(t *testing.T) {
+		t.Setenv("UNICITY_TEST_SLICE_EMPTY", " , , ")
+		def := []string{"x"}
+		got := getEnvStringSliceOrDefault("UNICITY_TEST_SLICE_EMPTY", def)
+		if !reflect.DeepEqual(got, def) {
+			t.Errorf("got %v, want %v", got, def)
+		}
+	})
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -54,9 +54,8 @@ func createRedisCommitmentQueue(ctx context.Context, cfg *config.Config, log *lo
 			ReadTimeout:      cfg.Redis.ReadTimeout,
 			WriteTimeout:     cfg.Redis.WriteTimeout,
 			PoolSize:         cfg.Redis.PoolSize,
+			MinIdleConns:     cfg.Redis.MinIdleConns,
 			MaxRetries:       cfg.Redis.MaxRetries,
-			RouteByLatency:   cfg.Redis.RouteByLatency,
-			RouteRandomly:    cfg.Redis.RouteRandomly,
 		})
 		if log != nil {
 			log.Info("redis commitment queue using sentinel mode",
@@ -75,6 +74,7 @@ func createRedisCommitmentQueue(ctx context.Context, cfg *config.Config, log *lo
 			ReadTimeout:  cfg.Redis.ReadTimeout,
 			WriteTimeout: cfg.Redis.WriteTimeout,
 			PoolSize:     cfg.Redis.PoolSize,
+			MinIdleConns: cfg.Redis.MinIdleConns,
 			MaxRetries:   cfg.Redis.MaxRetries,
 		})
 		if log != nil {

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -59,7 +59,15 @@ func createRedisCommitmentQueue(cfg *config.Config, log *logger.Logger) (interfa
 			RouteRandomly:    cfg.Redis.RouteRandomly,
 			ReplicaOnly:      cfg.Redis.ReplicaOnly,
 		})
+		if log != nil {
+			log.Info("redis commitment queue using sentinel mode",
+				"master", cfg.Redis.MasterName,
+				"sentinels", cfg.Redis.SentinelAddrs)
+		}
 	} else {
+		if cfg.Redis.MasterName != "" {
+			return nil, fmt.Errorf("REDIS_MASTER_NAME is set but REDIS_SENTINEL_ADDRS is empty; either set REDIS_SENTINEL_ADDRS or unset REDIS_MASTER_NAME")
+		}
 		redisClient = redislib.NewClient(&redislib.Options{
 			Addr:         fmt.Sprintf("%s:%d", cfg.Redis.Host, cfg.Redis.Port),
 			Password:     cfg.Redis.Password,
@@ -70,6 +78,10 @@ func createRedisCommitmentQueue(cfg *config.Config, log *logger.Logger) (interfa
 			PoolSize:     cfg.Redis.PoolSize,
 			MaxRetries:   cfg.Redis.MaxRetries,
 		})
+		if log != nil {
+			log.Info("redis commitment queue using direct mode",
+				"addr", fmt.Sprintf("%s:%d", cfg.Redis.Host, cfg.Redis.Port))
+		}
 	}
 
 	// Test connection

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -38,17 +38,39 @@ func NewStorage(ctx context.Context, cfg *config.Config, log *logger.Logger) (in
 
 // createRedisCommitmentQueue creates a Redis-based commitment queue
 func createRedisCommitmentQueue(cfg *config.Config, log *logger.Logger) (interfaces.CommitmentQueue, error) {
-	// Create Redis client
-	redisClient := redislib.NewClient(&redislib.Options{
-		Addr:         fmt.Sprintf("%s:%d", cfg.Redis.Host, cfg.Redis.Port),
-		Password:     cfg.Redis.Password,
-		DB:           cfg.Redis.DB,
-		DialTimeout:  cfg.Redis.DialTimeout,
-		ReadTimeout:  cfg.Redis.ReadTimeout,
-		WriteTimeout: cfg.Redis.WriteTimeout,
-		PoolSize:     cfg.Redis.PoolSize,
-		MaxRetries:   cfg.Redis.MaxRetries,
-	})
+	var redisClient *redislib.Client
+	if len(cfg.Redis.SentinelAddrs) > 0 {
+		if cfg.Redis.MasterName == "" {
+			return nil, fmt.Errorf("REDIS_MASTER_NAME is required when REDIS_SENTINEL_ADDRS is set")
+		}
+		redisClient = redislib.NewFailoverClient(&redislib.FailoverOptions{
+			MasterName:       cfg.Redis.MasterName,
+			SentinelAddrs:    cfg.Redis.SentinelAddrs,
+			SentinelUsername: cfg.Redis.SentinelUsername,
+			SentinelPassword: cfg.Redis.SentinelPassword,
+			Password:         cfg.Redis.Password,
+			DB:               cfg.Redis.DB,
+			DialTimeout:      cfg.Redis.DialTimeout,
+			ReadTimeout:      cfg.Redis.ReadTimeout,
+			WriteTimeout:     cfg.Redis.WriteTimeout,
+			PoolSize:         cfg.Redis.PoolSize,
+			MaxRetries:       cfg.Redis.MaxRetries,
+			RouteByLatency:   cfg.Redis.RouteByLatency,
+			RouteRandomly:    cfg.Redis.RouteRandomly,
+			ReplicaOnly:      cfg.Redis.ReplicaOnly,
+		})
+	} else {
+		redisClient = redislib.NewClient(&redislib.Options{
+			Addr:         fmt.Sprintf("%s:%d", cfg.Redis.Host, cfg.Redis.Port),
+			Password:     cfg.Redis.Password,
+			DB:           cfg.Redis.DB,
+			DialTimeout:  cfg.Redis.DialTimeout,
+			ReadTimeout:  cfg.Redis.ReadTimeout,
+			WriteTimeout: cfg.Redis.WriteTimeout,
+			PoolSize:     cfg.Redis.PoolSize,
+			MaxRetries:   cfg.Redis.MaxRetries,
+		})
+	}
 
 	// Test connection
 	ctx := context.Background()

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -24,7 +24,7 @@ func NewStorage(ctx context.Context, cfg *config.Config, log *logger.Logger) (in
 	// Choose commitment queue implementation
 	var commitmentQueue interfaces.CommitmentQueue
 	if cfg.Storage.UseRedisForCommitments {
-		commitmentQueue, err = createRedisCommitmentQueue(cfg, log)
+		commitmentQueue, err = createRedisCommitmentQueue(ctx, cfg, log)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create Redis commitment queue: %w", err)
 		}
@@ -37,7 +37,7 @@ func NewStorage(ctx context.Context, cfg *config.Config, log *logger.Logger) (in
 }
 
 // createRedisCommitmentQueue creates a Redis-based commitment queue
-func createRedisCommitmentQueue(cfg *config.Config, log *logger.Logger) (interfaces.CommitmentQueue, error) {
+func createRedisCommitmentQueue(ctx context.Context, cfg *config.Config, log *logger.Logger) (interfaces.CommitmentQueue, error) {
 	var redisClient *redislib.Client
 	if len(cfg.Redis.SentinelAddrs) > 0 {
 		if cfg.Redis.MasterName == "" {
@@ -57,7 +57,6 @@ func createRedisCommitmentQueue(cfg *config.Config, log *logger.Logger) (interfa
 			MaxRetries:       cfg.Redis.MaxRetries,
 			RouteByLatency:   cfg.Redis.RouteByLatency,
 			RouteRandomly:    cfg.Redis.RouteRandomly,
-			ReplicaOnly:      cfg.Redis.ReplicaOnly,
 		})
 		if log != nil {
 			log.Info("redis commitment queue using sentinel mode",
@@ -84,8 +83,6 @@ func createRedisCommitmentQueue(cfg *config.Config, log *logger.Logger) (interfa
 		}
 	}
 
-	// Test connection
-	ctx := context.Background()
 	if err := redisClient.Ping(ctx).Err(); err != nil {
 		return nil, fmt.Errorf("failed to connect to Redis: %w", err)
 	}

--- a/internal/storage/factory_test.go
+++ b/internal/storage/factory_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unicitynetwork/aggregator-go/internal/config"
+)
+
+// TestCreateRedisCommitmentQueue_SentinelRequiresMasterName verifies that the
+// factory rejects a configuration which sets REDIS_SENTINEL_ADDRS but leaves
+// REDIS_MASTER_NAME empty. The validation must trigger before any network I/O,
+// so this can run as a pure unit test (no Redis/MongoDB required).
+func TestCreateRedisCommitmentQueue_SentinelRequiresMasterName(t *testing.T) {
+	cfg := &config.Config{
+		Redis: config.RedisConfig{
+			SentinelAddrs: []string{"sentinel-1:26379", "sentinel-2:26379"},
+			MasterName:    "", // intentionally empty
+		},
+	}
+
+	q, err := createRedisCommitmentQueue(cfg, nil)
+	if err == nil {
+		t.Fatalf("expected error when SentinelAddrs is set but MasterName is empty, got queue=%v", q)
+	}
+	if q != nil {
+		t.Errorf("expected nil queue on validation error, got %v", q)
+	}
+	if !strings.Contains(err.Error(), "REDIS_MASTER_NAME") {
+		t.Errorf("expected error to mention REDIS_MASTER_NAME, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "REDIS_SENTINEL_ADDRS") {
+		t.Errorf("expected error to mention REDIS_SENTINEL_ADDRS, got: %v", err)
+	}
+}
+
+// TestCreateRedisCommitmentQueue_MasterNameWithoutSentinelAddrs guards the
+// reverse misconfiguration: REDIS_MASTER_NAME set but REDIS_SENTINEL_ADDRS
+// empty. Without this check the factory would silently fall back to
+// single-endpoint mode and ignore the master name — a real footgun for
+// operators who intended to enable Sentinel.
+func TestCreateRedisCommitmentQueue_MasterNameWithoutSentinelAddrs(t *testing.T) {
+	cfg := &config.Config{
+		Redis: config.RedisConfig{
+			Host:          "localhost",
+			Port:          6379,
+			SentinelAddrs: nil, // intentionally empty
+			MasterName:    "mymaster",
+		},
+	}
+
+	q, err := createRedisCommitmentQueue(cfg, nil)
+	if err == nil {
+		t.Fatalf("expected error when MasterName is set but SentinelAddrs is empty, got queue=%v", q)
+	}
+	if q != nil {
+		t.Errorf("expected nil queue on validation error, got %v", q)
+	}
+	if !strings.Contains(err.Error(), "REDIS_MASTER_NAME") || !strings.Contains(err.Error(), "REDIS_SENTINEL_ADDRS") {
+		t.Errorf("expected error to mention both REDIS_MASTER_NAME and REDIS_SENTINEL_ADDRS, got: %v", err)
+	}
+}

--- a/internal/storage/factory_test.go
+++ b/internal/storage/factory_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestCreateRedisCommitmentQueue_SentinelRequiresMasterName(t *testing.T) {
 		},
 	}
 
-	q, err := createRedisCommitmentQueue(cfg, nil)
+	q, err := createRedisCommitmentQueue(context.Background(), cfg, nil)
 	if err == nil {
 		t.Fatalf("expected error when SentinelAddrs is set but MasterName is empty, got queue=%v", q)
 	}
@@ -49,7 +50,7 @@ func TestCreateRedisCommitmentQueue_MasterNameWithoutSentinelAddrs(t *testing.T)
 		},
 	}
 
-	q, err := createRedisCommitmentQueue(cfg, nil)
+	q, err := createRedisCommitmentQueue(context.Background(), cfg, nil)
 	if err == nil {
 		t.Fatalf("expected error when MasterName is set but SentinelAddrs is empty, got queue=%v", q)
 	}

--- a/internal/storage/redis/sentinel_integration_test.go
+++ b/internal/storage/redis/sentinel_integration_test.go
@@ -1,0 +1,232 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	redislib "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcnetwork "github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/unicitynetwork/aggregator-go/internal/logger"
+	"github.com/unicitynetwork/aggregator-go/internal/models"
+	"github.com/unicitynetwork/aggregator-go/internal/storage/interfaces"
+)
+
+const (
+	sentinelMasterAlias = "redis-master"
+	sentinelMasterName  = "mymaster"
+)
+
+// sentinelTestEnv is a running redis master + redis-sentinel pair on a shared
+// Docker network. Master is reachable from inside the network at
+// sentinelMasterAlias:6379 and from the host at masterHostAddr; Sentinel is
+// reachable from the host at sentinelHostAddr.
+type sentinelTestEnv struct {
+	masterHostAddr   string
+	sentinelHostAddr string
+	network          *testcontainers.DockerNetwork
+	master           testcontainers.Container
+	sentinel         testcontainers.Container
+}
+
+func (e *sentinelTestEnv) close(ctx context.Context) {
+	if e.sentinel != nil {
+		_ = e.sentinel.Terminate(ctx)
+	}
+	if e.master != nil {
+		_ = e.master.Terminate(ctx)
+	}
+	if e.network != nil {
+		_ = e.network.Remove(ctx)
+	}
+}
+
+func startSentinelTestEnv(ctx context.Context, t *testing.T) *sentinelTestEnv {
+	t.Helper()
+
+	env := &sentinelTestEnv{}
+	t.Cleanup(func() { env.close(ctx) })
+
+	nw, err := tcnetwork.New(ctx)
+	require.NoError(t, err, "create docker network")
+	env.network = nw
+
+	masterReq := testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "redis:7-alpine",
+			ExposedPorts: []string{"6379/tcp"},
+			Networks:     []string{nw.Name},
+			NetworkAliases: map[string][]string{
+				nw.Name: {sentinelMasterAlias},
+			},
+			Cmd: []string{
+				"redis-server",
+				"--save", "",
+				"--appendonly", "no",
+			},
+			WaitingFor: wait.ForLog("Ready to accept connections"),
+		},
+		Started: true,
+	}
+	master, err := testcontainers.GenericContainer(ctx, masterReq)
+	require.NoError(t, err, "start redis master")
+	env.master = master
+
+	masterHost, err := master.Host(ctx)
+	require.NoError(t, err)
+	masterPort, err := master.MappedPort(ctx, "6379")
+	require.NoError(t, err)
+	env.masterHostAddr = fmt.Sprintf("%s:%s", masterHost, masterPort.Port())
+
+	sentinelConf := fmt.Sprintf(
+		"port 26379\n"+
+			"sentinel resolve-hostnames yes\n"+
+			"sentinel monitor %s %s 6379 1\n"+
+			"sentinel down-after-milliseconds %s 5000\n"+
+			"sentinel failover-timeout %s 10000\n"+
+			"sentinel parallel-syncs %s 1\n",
+		sentinelMasterName, sentinelMasterAlias,
+		sentinelMasterName, sentinelMasterName, sentinelMasterName,
+	)
+	confPath := filepath.Join(t.TempDir(), "sentinel.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(sentinelConf), 0o644))
+
+	sentinelReq := testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "redis:7-alpine",
+			ExposedPorts: []string{"26379/tcp"},
+			Networks:     []string{nw.Name},
+			Cmd:          []string{"redis-sentinel", "/etc/redis/sentinel.conf"},
+			Files: []testcontainers.ContainerFile{
+				{
+					HostFilePath:      confPath,
+					ContainerFilePath: "/etc/redis/sentinel.conf",
+					FileMode:          0o644,
+				},
+			},
+			WaitingFor: wait.ForAll(
+				wait.ForListeningPort("26379/tcp"),
+				wait.ForLog("+monitor master"),
+			).WithStartupTimeoutDefault(60 * time.Second),
+		},
+		Started: true,
+	}
+	sentinel, err := testcontainers.GenericContainer(ctx, sentinelReq)
+	require.NoError(t, err, "start redis-sentinel")
+	env.sentinel = sentinel
+
+	sentinelHost, err := sentinel.Host(ctx)
+	require.NoError(t, err)
+	sentinelPort, err := sentinel.MappedPort(ctx, "26379")
+	require.NoError(t, err)
+	env.sentinelHostAddr = fmt.Sprintf("%s:%s", sentinelHost, sentinelPort.Port())
+
+	return env
+}
+
+// dialerForSentinel translates master-port dials to the host-routable mapped
+// address. Sentinel resolves the master alias to the container's internal IP
+// at monitor time and returns that IP (e.g. 172.x.x.x:6379) to clients via
+// SENTINEL get-master-addr-by-name; tests run on the host where that IP is
+// not reachable. Any dial to port 6379 is redirected to the host-mapped
+// master, while sentinel dials (port 26379) pass through unchanged.
+func dialerForSentinel(env *sentinelTestEnv) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	d := net.Dialer{Timeout: 5 * time.Second}
+	return func(ctx context.Context, netw, addr string) (net.Conn, error) {
+		if _, port, err := net.SplitHostPort(addr); err == nil && port == "6379" {
+			addr = env.masterHostAddr
+		}
+		return d.DialContext(ctx, netw, addr)
+	}
+}
+
+// TestSentinelCommitmentQueueIntegration brings up redis master + redis-sentinel
+// via testcontainers and verifies that a CommitmentStorage backed by go-redis's
+// FailoverClient (the same client construction the production factory uses for
+// REDIS_SENTINEL_ADDRS) can store and read commitments end-to-end through
+// Sentinel-discovered master resolution.
+//
+// The production factory (createRedisCommitmentQueue) is bypassed because it
+// does not expose a Dialer hook: Sentinel returns the master's in-network
+// alias address to clients, but the test process runs on the host where the
+// alias is not resolvable. A test-only Dialer translates the alias to the
+// host-mapped address. Factory validation is covered by factory_test.go.
+func TestSentinelCommitmentQueueIntegration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	env := startSentinelTestEnv(ctx, t)
+
+	log, err := logger.New("info", "text", "stdout", false)
+	require.NoError(t, err)
+
+	client := redislib.NewFailoverClient(&redislib.FailoverOptions{
+		MasterName:    sentinelMasterName,
+		SentinelAddrs: []string{env.sentinelHostAddr},
+		Dialer:        dialerForSentinel(env),
+		DialTimeout:   5 * time.Second,
+		ReadTimeout:   3 * time.Second,
+		WriteTimeout:  3 * time.Second,
+		PoolSize:      10,
+		MaxRetries:    3,
+	})
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.NoError(t, client.Ping(ctx).Err(), "Sentinel-backed Ping failed")
+
+	storage := NewCommitmentStorage(client, "commitments-sentinel-test", "test-server", DefaultBatchConfig(), log)
+	require.NoError(t, storage.Initialize(ctx))
+	t.Cleanup(func() {
+		_ = storage.Cleanup(ctx)
+		_ = storage.Close(ctx)
+	})
+
+	commitments := []*models.CertificationRequest{
+		createTestCommitment(),
+		createTestCommitment(),
+		createTestCommitment(),
+	}
+	for _, c := range commitments {
+		require.NoError(t, storage.Store(ctx, c))
+	}
+
+	streamCtx, streamCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer streamCancel()
+
+	out := make(chan *models.CertificationRequest, len(commitments))
+	go func() { _ = storage.StreamCertificationRequests(streamCtx, out) }()
+
+	streamed := make([]*models.CertificationRequest, 0, len(commitments))
+	deadline := time.After(4 * time.Second)
+collect:
+	for len(streamed) < len(commitments) {
+		select {
+		case c := <-out:
+			streamed = append(streamed, c)
+		case <-deadline:
+			break collect
+		}
+	}
+	require.Len(t, streamed, len(commitments),
+		"expected to stream %d commitments through Sentinel-backed queue, got %d",
+		len(commitments), len(streamed))
+
+	acks := make([]interfaces.CertificationRequestAck, len(streamed))
+	for i, c := range streamed {
+		acks[i] = interfaces.CertificationRequestAck{StateID: c.StateID, StreamID: c.StreamID}
+	}
+	require.NoError(t, storage.MarkProcessed(ctx, acks))
+
+	pending, err := storage.CountUnprocessed(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), pending,
+		"expected queue to be drained after MarkProcessed via Sentinel-backed client")
+}


### PR DESCRIPTION
Closes #148.

## Summary
- Adds Redis Sentinel support for the commitment queue while keeping the existing single-endpoint path byte-equivalent for current deployments.
- `RedisConfig` gains `SentinelAddrs`, `MasterName`, `SentinelPassword`, `SentinelUsername` (env vars `REDIS_SENTINEL_ADDRS`, `REDIS_MASTER_NAME`, `REDIS_SENTINEL_PASSWORD`, `REDIS_SENTINEL_USERNAME`).
- `internal/storage/factory.go::createRedisCommitmentQueue` branches on `len(SentinelAddrs) > 0`: Sentinel mode uses `redislib.NewFailoverClient`, otherwise the original `redislib.NewClient` path runs unchanged. Both constructors return `*redis.Client`, so no downstream signature changes. The factory now takes a `context.Context` so the initial `Ping` honors upstream timeouts.
- Symmetric misconfiguration guards: setting `REDIS_SENTINEL_ADDRS` without `REDIS_MASTER_NAME` (and vice versa) returns a clear error at startup instead of silently falling back to single-endpoint mode.
- Logs the active mode (`sentinel`/`direct`) at queue construction time so HA wiring is verifiable from startup logs.
- Wires the existing `REDIS_MIN_IDLE_CONNS` env var through both client constructors (it was previously loaded into `RedisConfig` but never passed to the redis options).
- README.md documents the new env vars; `changes.txt` has a dated entry. Two pre-existing stale defaults in the README's Storage Configuration table (`REDIS_FLUSH_INTERVAL`, `REDIS_MAX_BATCH_SIZE`) are corrected to match the code.

## Why no `ReplicaOnly` / `RouteByLatency` / `RouteRandomly` knobs
`go-redis` exposes these `FailoverOptions` to send some or all commands to read-only replicas. Most queue commands (`XADD`/`XACK`/`XReadGroup`/`XAutoClaim`) are classified as writes and would hit master regardless, but `XPendingExt` **is** read-only — with any of these flags on it would route to a replica and observe replication-lagged consumer-group state, silently re-delivering already-acked entries. They are intentionally not exposed; there is no legitimate use case for any of them in this component.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./internal/config/...` — sentinel env parsing, defaults, comma-separated slice helper
- [x] `go test -count=1 ./internal/storage/...` — factory validation guards (both directions) plus existing storage tests including the testcontainer-backed Redis stream tests
- [x] `go test -count=1 -race ./internal/config/... ./internal/storage/...` clean
- [x] `go test -count=1 -run TestSentinelCommitmentQueueIntegration ./internal/storage/redis/` — new integration test brings up redis master + redis-sentinel via testcontainers and runs the full Store → Stream → MarkProcessed pipeline through Sentinel-discovered master resolution

## Backwards compatibility
Existing deployments using `REDIS_HOST`/`REDIS_PORT` continue to work without any config change. `UniversalClient` was considered but rejected in favor of `NewFailoverClient` because it returns `*redis.Client` directly, keeping `internal/storage/redis/commitment.go` and other downstream consumers untouched.

## Out of scope
- Redis Cluster mode.
- A `sentinel-compose.yml` example deployment.
- An end-to-end failover test (kill master, observe queue recovery) — worth a follow-up issue.