### PR TITLE
fix: remove leftover blocks finalized/status backfill migration

### DIFF
--- a/internal/storage/mongodb/block.go
+++ b/internal/storage/mongodb/block.go
@@ -270,24 +270,6 @@ func (bs *BlockStorage) CreateIndexes(ctx context.Context) error {
 		return fmt.Errorf("failed to create block indexes: %w", err)
 	}
 
-	// Migration: Set finalized=true for old blocks without the field. Remove after deployment.
-	_, err = bs.collection.UpdateMany(ctx,
-		bson.M{"finalized": bson.M{"$exists": false}},
-		bson.M{"$set": bson.M{"finalized": true}},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to migrate blocks finalized field: %w", err)
-	}
-	_, err = bs.collection.UpdateMany(ctx,
-		bson.M{"status": bson.M{"$exists": false}},
-		[]bson.M{
-			{"$set": bson.M{"status": bson.M{"$cond": []interface{}{"$finalized", models.FinalityStatusFinalized, models.FinalityStatusFinalizing}}}},
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to migrate blocks status field: %w", err)
-	}
-
 	return nil
 }
 

--- a/internal/storage/mongodb/block_test.go
+++ b/internal/storage/mongodb/block_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/mongodb"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
@@ -696,4 +697,29 @@ func TestBlockStorage_GetNextFinalizedAfter(t *testing.T) {
 	next, err = storage.GetNextFinalizedAfter(ctx, api.NewBigInt(big.NewInt(4)), api.NewBigInt(big.NewInt(4)))
 	require.NoError(t, err)
 	require.Nil(t, next)
+}
+
+// CreateIndexes runs on every startup, so it must not mutate documents: the
+// old finalized/status backfill migration COLLSCANed the whole collection on
+// boot and crash-looped large deployments (issue #171).
+func TestBlockStorage_CreateIndexes_DoesNotMutateDocuments(t *testing.T) {
+	db, cleanup := setupBlockTestDB(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), blockTestTimeout)
+	defer cancel()
+
+	storage := NewBlockStorage(db)
+
+	legacy := bson.M{"index": bigIntToDecimal128(api.NewBigInt(big.NewInt(1))), "chainId": "test"}
+	_, err := db.Collection(blockCollection).InsertOne(ctx, legacy)
+	require.NoError(t, err)
+
+	require.NoError(t, storage.CreateIndexes(ctx))
+
+	var doc bson.M
+	err = db.Collection(blockCollection).FindOne(ctx, bson.M{"chainId": "test"}).Decode(&doc)
+	require.NoError(t, err)
+	assert.NotContains(t, doc, "finalized")
+	assert.NotContains(t, doc, "status")
 }


### PR DESCRIPTION
## Summary

Removes the two one-time backfill `UpdateMany({$exists: false})` calls from `BlockStorage.CreateIndexes`, as instructed by their own comment ("Remove after deployment").

These ran on **every startup** and cannot use an index, so each was a full COLLSCAN of the `blocks` collection. On large deployments the scan exceeds the Mongo client timeout, `CreateIndexes` fails, storage init fails, and the node crash-loops on any restart — while the orphaned server-side scans keep running and pile up on the primary (observed: load ~125, degraded block production across all shards).

The backfill matches zero documents on any live dataset: all block writers (`Store`, `SetFinalized`, `SetStatus`, `SetFinalizedWithCertificate`) have populated `finalized`/`status` since the fields were introduced. The recovery-path reader `finalizingBlockFilter()` still tolerates legacy documents without `status`, so even a hypothetical unmigrated backup keeps working on the read path; re-backfilling such data is an out-of-band admin task per the issue.

## Changes

- `internal/storage/mongodb/block.go`: drop both backfill `UpdateMany` calls; `CreateIndexes` now only creates indexes.
- `internal/storage/mongodb/block_test.go`: regression test `TestBlockStorage_CreateIndexes_DoesNotMutateDocuments` — inserts a legacy-shaped document (no `finalized`/`status`), runs `CreateIndexes`, asserts the document is untouched. Fails if a startup-path data mutation is ever reintroduced.

## Testing

- `go build ./...`, `go vet ./internal/storage/...`
- `go test -run TestBlockStorage ./internal/storage/mongodb/` (testcontainers Mongo 7.0) — all pass, including the new regression test.

Fixes #171