### PR TITLE
Fix round recovery and MongoDB transaction retries

### DIFF
--- a/internal/bft/client.go
+++ b/internal/bft/client.go
@@ -412,40 +412,51 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 
 	wasInitializing := c.status.Load() == initializing
 	if wasInitializing {
-		c.logger.WithContext(ctx).Info("BFT client initialization finished, starting first round",
+		c.logger.WithContext(ctx).Info("BFT client initialization finished",
 			"nextRoundNumber", nextRoundNumber.String())
 		// First UC received after an initial handshake with a root node -> initialization finished.
 		c.status.Store(normal)
-		recovered, err := c.finalizeCertifiedDurableProposalLocked(ctx, uc)
-		if err != nil {
-			return err
-		}
-		if recovered {
-			c.logger.WithContext(ctx).Info("Durable proposal finalized from initialization UC",
-				"ucRound", uc.GetRoundNumber(),
+
+		// If startup already proposed a block and this UC certifies it, continue
+		// through the normal proposed-block finalization path below. Otherwise
+		// the initialization branch can skip finalization and start the next
+		// round with a live proposed block still in memory.
+		if c.proposedBlock != nil && c.proposedBlock.Index.Uint64() == uc.GetRoundNumber() {
+			c.logger.WithContext(ctx).Info("Initialization UC matches proposed block; finalizing normally",
+				"blockNumber", c.proposedBlock.Index.String(),
 				"nextRoundNumber", nextRoundNumber.String())
-			err := c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
+		} else {
+			recovered, err := c.finalizeCertifiedDurableProposalLocked(ctx, uc)
 			if err != nil {
-				c.logger.WithContext(ctx).Error("Failed to start first round after durable proposal recovery",
+				return err
+			}
+			if recovered {
+				c.logger.WithContext(ctx).Info("Durable proposal finalized from initialization UC",
+					"ucRound", uc.GetRoundNumber(),
+					"nextRoundNumber", nextRoundNumber.String())
+				err := c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
+				if err != nil {
+					c.logger.WithContext(ctx).Error("Failed to start first round after durable proposal recovery",
+						"nextRoundNumber", nextRoundNumber.String(),
+						"error", err.Error())
+				}
+				return err
+			}
+			resumed, err := c.resumeDurableProposalLocked(ctx, api.NewBigInt(nextRoundNumber))
+			if err != nil {
+				return err
+			}
+			if resumed {
+				return nil
+			}
+			err = c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
+			if err != nil {
+				c.logger.WithContext(ctx).Error("Failed to start first round after initialization",
 					"nextRoundNumber", nextRoundNumber.String(),
 					"error", err.Error())
 			}
 			return err
 		}
-		resumed, err := c.resumeDurableProposalLocked(ctx, api.NewBigInt(nextRoundNumber))
-		if err != nil {
-			return err
-		}
-		if resumed {
-			return nil
-		}
-		err = c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
-		if err != nil {
-			c.logger.WithContext(ctx).Error("Failed to start first round after initialization",
-				"nextRoundNumber", nextRoundNumber.String(),
-				"error", err.Error())
-		}
-		return err
 	}
 
 	// Check if we have a proposed block that matches the UC round

--- a/internal/bft/client.go
+++ b/internal/bft/client.go
@@ -30,6 +30,7 @@ const (
 	idle status = iota
 	initializing
 	normal
+	stopping
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 	ErrCertifiedRootMismatch   = errors.New("certified root does not match proposed block root")
 	ErrInvalidUCSequence       = errors.New("invalid unicity certificate sequence")
 	ErrCertifiedStateMismatch  = errors.New("local committed state does not match latest certified root")
+	ErrBFTClientStopping       = errors.New("BFT client is stopping")
 )
 
 // BFTClientImpl handles communication with the BFT root chain via P2P network
@@ -49,7 +51,7 @@ type (
 		logger      *logger.Logger
 		eventBus    *events.EventBus
 
-		// mutex for peer, network, signer TODO: there are readers without mutex
+		// Protects peer, network, and signer.
 		mu      sync.Mutex
 		peer    *network.Peer
 		network *BftNetwork
@@ -70,6 +72,8 @@ type (
 		ucProcessingMutex sync.Mutex
 
 		msgLoopCancelFn context.CancelFunc
+		msgLoopDone     chan struct{}
+		stopDone        chan struct{}
 
 		// timestamp when last UC was received
 		lastCertResponseTime atomic.Int64
@@ -161,17 +165,37 @@ func (c *BFTClientImpl) Start(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.status.Load().(status) != idle {
+	clientStatus := c.status.Load().(status)
+	if clientStatus == stopping {
+		return ErrBFTClientStopping
+	}
+	if clientStatus != idle {
 		c.logger.WithContext(ctx).Warn("BFT Client is not idle, skipping start")
 		return nil
 	}
 	c.status.Store(initializing)
+	started := false
+	var self *network.Peer
+	defer func() {
+		if started {
+			return
+		}
+		if self != nil {
+			if err := self.Close(); err != nil {
+				c.logger.WithContext(ctx).Error("Failed to close partially initialized peer", "error", err)
+			}
+		}
+		c.peer = nil
+		c.network = nil
+		c.signer = nil
+		c.status.Store(idle)
+	}()
 
 	peerConf, err := c.conf.PeerConf()
 	if err != nil {
 		return fmt.Errorf("failed to create peer configuration: %w", err)
 	}
-	self, err := network.NewPeer(ctx, peerConf, c.logger.Logger, nil)
+	self, err = network.NewPeer(ctx, peerConf, c.logger.Logger, nil)
 	if err != nil {
 		return err
 	}
@@ -185,18 +209,21 @@ func (c *BFTClientImpl) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to create libp2p network: %w", err)
 	}
 
+	if err := self.BootstrapConnect(ctx, c.logger.Logger); err != nil {
+		return fmt.Errorf("failed to bootstrap peer: %w", err)
+	}
+
 	c.peer = self
 	c.network = networkP2P
 	c.signer = signer
 
-	if err := c.peer.BootstrapConnect(ctx, c.logger.Logger); err != nil {
-		return fmt.Errorf("failed to bootstrap peer: %w", err)
-	}
-
 	msgLoopCtx, cancelFn := context.WithCancel(ctx)
 	c.msgLoopCancelFn = cancelFn
+	msgLoopDone := make(chan struct{})
+	c.msgLoopDone = msgLoopDone
 	nodeID := self.ID().String()
 	go func() {
+		defer close(msgLoopDone)
 		c.logger.WithContext(ctx).Info("BFT client event loop started")
 		if err := c.loop(msgLoopCtx, networkP2P, nodeID); err != nil {
 			c.logger.Error("BFT event loop thread exited with error", "error", err.Error())
@@ -204,6 +231,7 @@ func (c *BFTClientImpl) Start(ctx context.Context) error {
 			c.logger.Info("BFT event loop thread finished")
 		}
 	}()
+	started = true
 
 	return nil
 }
@@ -211,19 +239,34 @@ func (c *BFTClientImpl) Start(ctx context.Context) error {
 func (c *BFTClientImpl) Stop() {
 	c.logger.Info("Stopping BFT Client")
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
-	if c.status.Load().(status) == idle {
+	clientStatus := c.status.Load().(status)
+	if clientStatus == idle {
+		c.mu.Unlock()
 		c.logger.Warn("BFT Client is already idle, skipping stop")
 		return
 	}
+	if clientStatus == stopping {
+		stopDone := c.stopDone
+		c.mu.Unlock()
+		if stopDone != nil {
+			<-stopDone
+		}
+		return
+	}
 
-	c.status.Store(idle)
-
+	c.status.Store(stopping)
+	stopDone := make(chan struct{})
+	c.stopDone = stopDone
 	if c.msgLoopCancelFn != nil {
 		c.msgLoopCancelFn()
 		c.msgLoopCancelFn = nil
 	}
+	c.mu.Unlock()
+
+	// Cancel first so in-flight UC processing can unblock before Stop waits for it.
+	c.ucProcessingMutex.Lock()
+	c.mu.Lock()
 	if c.peer != nil {
 		if err := c.peer.Close(); err != nil {
 			c.logger.Error("Failed to close peer host", "error", err)
@@ -232,6 +275,27 @@ func (c *BFTClientImpl) Stop() {
 		c.network = nil
 		c.signer = nil
 	}
+
+	// Proposal state belongs to this BFT session. The durable proposal in
+	// storage is the recovery source after a restart or HA reactivation.
+	c.proposedBlock = nil
+	c.resumedDurableProposal = false
+	c.certRequestTime.Store(0)
+
+	msgLoopDone := c.msgLoopDone
+	c.msgLoopDone = nil
+	c.mu.Unlock()
+	c.ucProcessingMutex.Unlock()
+
+	if msgLoopDone != nil {
+		<-msgLoopDone
+	}
+
+	c.mu.Lock()
+	c.status.Store(idle)
+	c.stopDone = nil
+	close(stopDone)
+	c.mu.Unlock()
 }
 
 func (c *BFTClientImpl) sendHandshake(ctx context.Context, bftNetwork *BftNetwork, nodeID string) error {
@@ -341,12 +405,34 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 	// Ensure sequential processing of UCs to prevent race conditions
 	c.ucProcessingMutex.Lock()
 	defer c.ucProcessingMutex.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	c.logger.WithContext(ctx).Debug("Acquired UC processing lock",
 		"ucRound", uc.GetRoundNumber(),
 		"rootRound", uc.GetRootRoundNumber())
 
 	prevLUC := c.luc.Load()
+	wasInitializing := c.status.Load() == initializing
+	previousRootRound := c.lastRootRound.Load()
+	previousExpectedRound := c.nextExpectedRound.Load()
+	previousExpectedEpoch := c.nextExpectedEpoch.Load()
+	rollbackInitialization := func() {
+		if !wasInitializing {
+			return
+		}
+		c.luc.Store(prevLUC)
+		c.lastRootRound.Store(previousRootRound)
+		c.nextExpectedRound.Store(previousExpectedRound)
+		c.nextExpectedEpoch.Store(previousExpectedEpoch)
+	}
+	completeInitialization := func() {
+		if wasInitializing {
+			c.status.CompareAndSwap(initializing, normal)
+		}
+	}
+
 	if prevLUC != nil {
 		if err := types.CheckNonEquivocatingCertificates(prevLUC, uc); err != nil {
 			return fmt.Errorf("%w: %w", ErrInvalidUCSequence, err)
@@ -354,8 +440,13 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 	}
 	// as we can be connected to several root nodes, we can receive the same UC multiple times
 	if uc.IsDuplicate(prevLUC) {
-		c.logger.WithContext(ctx).Debug(fmt.Sprintf("duplicate UC (same root round %d)", uc.GetRootRoundNumber()))
-		return nil
+		if !wasInitializing {
+			c.logger.WithContext(ctx).Debug(fmt.Sprintf("duplicate UC (same root round %d)", uc.GetRootRoundNumber()))
+			return nil
+		}
+		c.logger.WithContext(ctx).Info("Using retained UC to complete BFT client initialization",
+			"partitionRound", uc.GetRoundNumber(),
+			"rootRound", uc.GetRootRoundNumber())
 	}
 
 	isRepeat, err := uc.IsRepeat(prevLUC)
@@ -385,7 +476,12 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 
 		c.logger.WithContext(ctx).Info("Starting new round after repeat UC",
 			"nextRoundNumber", nextRoundNumber.String())
-		return c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
+		if err := c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber)); err != nil {
+			rollbackInitialization()
+			return err
+		}
+		completeInitialization()
+		return nil
 	}
 
 	// Log both partition and root rounds for better tracking
@@ -410,53 +506,52 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 	c.nextExpectedRound.Store(tr.Round)
 	c.nextExpectedEpoch.Store(tr.Epoch)
 
-	wasInitializing := c.status.Load() == initializing
 	if wasInitializing {
 		c.logger.WithContext(ctx).Info("BFT client initialization finished",
 			"nextRoundNumber", nextRoundNumber.String())
-		// First UC received after an initial handshake with a root node -> initialization finished.
-		c.status.Store(normal)
 
-		// If startup already proposed a block and this UC certifies it, continue
-		// through the normal proposed-block finalization path below. Otherwise
-		// the initialization branch can skip finalization and start the next
-		// round with a live proposed block still in memory.
-		if c.proposedBlock != nil && c.proposedBlock.Index.Uint64() == uc.GetRoundNumber() {
-			c.logger.WithContext(ctx).Info("Initialization UC matches proposed block; finalizing normally",
-				"blockNumber", c.proposedBlock.Index.String(),
-				"nextRoundNumber", nextRoundNumber.String())
-		} else {
-			recovered, err := c.finalizeCertifiedDurableProposalLocked(ctx, uc)
-			if err != nil {
-				return err
-			}
-			if recovered {
-				c.logger.WithContext(ctx).Info("Durable proposal finalized from initialization UC",
-					"ucRound", uc.GetRoundNumber(),
-					"nextRoundNumber", nextRoundNumber.String())
-				err := c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
-				if err != nil {
-					c.logger.WithContext(ctx).Error("Failed to start first round after durable proposal recovery",
-						"nextRoundNumber", nextRoundNumber.String(),
-						"error", err.Error())
-				}
-				return err
-			}
-			resumed, err := c.resumeDurableProposalLocked(ctx, api.NewBigInt(nextRoundNumber))
-			if err != nil {
-				return err
-			}
-			if resumed {
-				return nil
-			}
-			err = c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
-			if err != nil {
-				c.logger.WithContext(ctx).Error("Failed to start first round after initialization",
-					"nextRoundNumber", nextRoundNumber.String(),
-					"error", err.Error())
-			}
+		recovered, err := c.finalizeCertifiedDurableProposalLocked(ctx, uc)
+		if err != nil {
+			rollbackInitialization()
 			return err
 		}
+		if recovered {
+			c.logger.WithContext(ctx).Info("Durable proposal finalized from initialization UC",
+				"ucRound", uc.GetRoundNumber(),
+				"nextRoundNumber", nextRoundNumber.String())
+			err := c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
+			if err != nil {
+				c.logger.WithContext(ctx).Error("Failed to start first round after durable proposal recovery",
+					"nextRoundNumber", nextRoundNumber.String(),
+					"error", err.Error())
+				rollbackInitialization()
+				return err
+			}
+			completeInitialization()
+			return nil
+		}
+		resumed, err := c.resumeDurableProposalLocked(ctx, api.NewBigInt(nextRoundNumber))
+		if err != nil {
+			c.proposedBlock = nil
+			c.resumedDurableProposal = false
+			c.certRequestTime.Store(0)
+			rollbackInitialization()
+			return err
+		}
+		if resumed {
+			completeInitialization()
+			return nil
+		}
+		err = c.roundManager.StartNewRound(ctx, api.NewBigInt(nextRoundNumber))
+		if err != nil {
+			c.logger.WithContext(ctx).Error("Failed to start first round after initialization",
+				"nextRoundNumber", nextRoundNumber.String(),
+				"error", err.Error())
+			rollbackInitialization()
+			return err
+		}
+		completeInitialization()
+		return nil
 	}
 
 	// Check if we have a proposed block that matches the UC round
@@ -526,12 +621,7 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 						"ucRound", expectedRound,
 						"error", err.Error())
 					metrics.BFTErrorsTotal.Inc()
-					if c.eventBus != nil {
-						c.eventBus.Publish(events.TopicFatalError, events.FatalErrorEvent{
-							Source: "bft",
-							Error:  err.Error(),
-						})
-					}
+					c.publishFatalError(ctx, err)
 					return fmt.Errorf("failed to finalize durable proposal: %w", err)
 				}
 				if recovered {
@@ -584,12 +674,7 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 				"error", abandonErr.Error())
 		}
 		metrics.BFTErrorsTotal.Inc()
-		if c.eventBus != nil {
-			c.eventBus.Publish(events.TopicFatalError, events.FatalErrorEvent{
-				Source: "bft",
-				Error:  err.Error(),
-			})
-		}
+		c.publishFatalError(ctx, err)
 		return err
 	}
 
@@ -605,6 +690,7 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 	if err != nil {
 		c.logger.WithContext(ctx).Error("Failed to encode unicity certificate",
 			"error", err.Error())
+		rollbackInitialization()
 		return fmt.Errorf("failed to encode unicity certificate: %w", err)
 	}
 	c.proposedBlock.UnicityCertificate = api.NewHexBytes(ucCbor)
@@ -612,6 +698,7 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 	if c.resumedDurableProposal {
 		finalizer, ok := c.roundManager.(DurableProposalFinalizer)
 		if !ok {
+			rollbackInitialization()
 			return errors.New("round manager does not support durable proposal finalization")
 		}
 		recovered, err := finalizer.FinalizeCertifiedProposal(ctx,
@@ -624,15 +711,12 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 				"blockNumber", c.proposedBlock.Index.String(),
 				"error", err.Error())
 			metrics.BFTErrorsTotal.Inc()
-			if c.eventBus != nil {
-				c.eventBus.Publish(events.TopicFatalError, events.FatalErrorEvent{
-					Source: "bft",
-					Error:  err.Error(),
-				})
-			}
+			c.publishFatalError(ctx, err)
+			rollbackInitialization()
 			return fmt.Errorf("failed to finalize resumed durable proposal: %w", err)
 		}
 		if !recovered {
+			rollbackInitialization()
 			return fmt.Errorf("resumed durable proposal %s was not finalized", c.proposedBlock.Index.String())
 		}
 		c.proposedBlock = nil
@@ -645,8 +729,11 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 			c.logger.WithContext(ctx).Error("Failed to start new round",
 				"nextRoundNumber", nextRoundNumber.String(),
 				"error", err.Error())
+			rollbackInitialization()
+			return err
 		}
-		return err
+		completeInitialization()
+		return nil
 	}
 
 	if err := c.roundManager.FinalizeBlockWithRetry(ctx, c.proposedBlock); err != nil {
@@ -654,12 +741,7 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 			"blockNumber", c.proposedBlock.Index.String(),
 			"error", err.Error())
 		metrics.BFTErrorsTotal.Inc()
-		if c.eventBus != nil {
-			c.eventBus.Publish(events.TopicFatalError, events.FatalErrorEvent{
-				Source: "bft",
-				Error:  err.Error(),
-			})
-		}
+		c.publishFatalError(ctx, err)
 		return fmt.Errorf("failed to finalize block after retries: %w", err)
 	}
 
@@ -677,6 +759,19 @@ func (c *BFTClientImpl) handleUnicityCertificate(ctx context.Context, uc *types.
 			"error", err.Error())
 	}
 	return err
+}
+
+func (c *BFTClientImpl) publishFatalError(ctx context.Context, err error) {
+	if errors.Is(err, context.Canceled) {
+		c.logger.WithContext(ctx).Info("Ignoring finalization cancellation during BFT client shutdown")
+		return
+	}
+	if c.eventBus != nil {
+		c.eventBus.Publish(events.TopicFatalError, events.FatalErrorEvent{
+			Source: "bft",
+			Error:  err.Error(),
+		})
+	}
 }
 
 func (c *BFTClientImpl) finalizeCertifiedDurableProposalLocked(ctx context.Context, uc *types.UnicityCertificate) (bool, error) {
@@ -786,7 +881,12 @@ func (c *BFTClientImpl) sendCertificationRequest(ctx context.Context, rootHash s
 	if err := c.verifyLocalRootExtendsLatestUC(ctx, luc); err != nil {
 		return err
 	}
-	if c.network == nil || c.peer == nil || c.signer == nil {
+	c.mu.Lock()
+	bftNetwork := c.network
+	peer := c.peer
+	signer := c.signer
+	c.mu.Unlock()
+	if bftNetwork == nil || peer == nil || signer == nil {
 		return errors.New("BFT client network is not initialized")
 	}
 
@@ -794,11 +894,11 @@ func (c *BFTClientImpl) sendCertificationRequest(ctx context.Context, rootHash s
 	req := &certification.BlockCertificationRequest{
 		PartitionID: c.PartitionID(),
 		ShardID:     c.ShardID(),
-		NodeID:      c.peer.ID().String(),
+		NodeID:      peer.ID().String(),
 		InputRecord: inputRecord,
 	}
 
-	if err = req.Sign(c.signer); err != nil {
+	if err = req.Sign(signer); err != nil {
 		return fmt.Errorf("failed to sign certification request: %w", err)
 	}
 	c.logger.WithContext(ctx).Info(fmt.Sprintf("Round %d sending block certification request to root chain, IR hash %X",
@@ -812,7 +912,7 @@ func (c *BFTClientImpl) sendCertificationRequest(ctx context.Context, rootHash s
 	if err != nil {
 		return fmt.Errorf("selecting root nodes: %w", err)
 	}
-	return c.network.Send(ctx, req, rootIDs...)
+	return bftNetwork.Send(ctx, req, rootIDs...)
 }
 
 func (c *BFTClientImpl) buildCertificationInputRecord(luc *types.UnicityCertificate, rootHashBytes []byte, roundNumber uint64) (*types.InputRecord, error) {
@@ -880,49 +980,47 @@ func (c *BFTClientImpl) CertificationRequest(ctx context.Context, block *models.
 		return err
 	}
 
-	if err := func() error {
-		c.ucProcessingMutex.Lock()
-		defer c.ucProcessingMutex.Unlock()
-
-		// The block root is computed for its original block number. If BFT has
-		// already moved to another round, this proposal is stale and must be dropped.
-		expectedRound := c.nextExpectedRound.Load()
-		if expectedRound > 0 {
-			blockNumber := block.Index.Uint64()
-			if expectedRound != blockNumber {
-				c.logger.WithContext(ctx).Warn("Rejecting stale certification request",
-					"blockNumber", blockNumber,
-					"expectedRound", expectedRound,
-					"difference", int64(expectedRound)-int64(blockNumber))
-				return fmt.Errorf("%w: expected round %d, got %d", ErrStaleCertificationRound, expectedRound, blockNumber)
-			}
-			c.logger.WithContext(ctx).Debug("Block number matches root chain expectations",
-				"blockNumber", expectedRound)
-		} else {
-			// No expected round yet - this might be the very first request
-			c.logger.WithContext(ctx).Debug("No expected round number from root chain yet, using proposed block number",
-				"blockNumber", block.Index.String())
-			// If we have a last UC, we can infer the expected round
-			if luc := c.luc.Load(); luc != nil {
-				// The next round should be the UC round + 1
-				inferredRound := luc.GetRoundNumber() + 1
-				if inferredRound != block.Index.Uint64() {
-					c.logger.WithContext(ctx).Warn("Rejecting stale certification request inferred from last UC",
-						"lastUCRound", luc.GetRoundNumber(),
-						"inferredRound", inferredRound,
-						"proposedRound", block.Index.Uint64())
-					return fmt.Errorf("%w: expected round %d, got %d", ErrStaleCertificationRound, inferredRound, block.Index.Uint64())
-				}
-			}
-		}
-
-		c.proposedBlock = block
-		c.resumedDurableProposal = false
-		c.certRequestTime.Store(time.Now().UnixNano())
-		return nil
-	}(); err != nil {
+	c.ucProcessingMutex.Lock()
+	defer c.ucProcessingMutex.Unlock()
+	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	// The block root is computed for its original block number. If BFT has
+	// already moved to another round, this proposal is stale and must be dropped.
+	expectedRound := c.nextExpectedRound.Load()
+	if expectedRound > 0 {
+		blockNumber := block.Index.Uint64()
+		if expectedRound != blockNumber {
+			c.logger.WithContext(ctx).Warn("Rejecting stale certification request",
+				"blockNumber", blockNumber,
+				"expectedRound", expectedRound,
+				"difference", int64(expectedRound)-int64(blockNumber))
+			return fmt.Errorf("%w: expected round %d, got %d", ErrStaleCertificationRound, expectedRound, blockNumber)
+		}
+		c.logger.WithContext(ctx).Debug("Block number matches root chain expectations",
+			"blockNumber", expectedRound)
+	} else {
+		// No expected round yet - this might be the very first request
+		c.logger.WithContext(ctx).Debug("No expected round number from root chain yet, using proposed block number",
+			"blockNumber", block.Index.String())
+		// If we have a last UC, we can infer the expected round
+		if luc := c.luc.Load(); luc != nil {
+			// The next round should be the UC round + 1
+			inferredRound := luc.GetRoundNumber() + 1
+			if inferredRound != block.Index.Uint64() {
+				c.logger.WithContext(ctx).Warn("Rejecting stale certification request inferred from last UC",
+					"lastUCRound", luc.GetRoundNumber(),
+					"inferredRound", inferredRound,
+					"proposedRound", block.Index.Uint64())
+				return fmt.Errorf("%w: expected round %d, got %d", ErrStaleCertificationRound, inferredRound, block.Index.Uint64())
+			}
+		}
+	}
+
+	c.proposedBlock = block
+	c.resumedDurableProposal = false
+	c.certRequestTime.Store(time.Now().UnixNano())
 
 	c.logger.WithContext(ctx).Debug("Sending certification request",
 		"blockNumber", block.Index.String(),
@@ -963,8 +1061,19 @@ func (c *BFTClientImpl) ensureInitialized(ctx context.Context) error {
 	if c.status.Load() == normal {
 		return nil
 	}
-	_, err := c.waitForLatestUC(ctx)
-	return err
+
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if c.status.Load() == normal {
+				return nil
+			}
+		}
+	}
 }
 
 // WaitForInitialized blocks until the BFT client has received its first UC and is ready.

--- a/internal/bft/client_stub_test.go
+++ b/internal/bft/client_stub_test.go
@@ -9,14 +9,52 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	cmdbft "github.com/unicitynetwork/bft-core/cli/ubft/cmd"
 	"github.com/unicitynetwork/bft-core/network/protocol/certification"
+	abcrypto "github.com/unicitynetwork/bft-go-base/crypto"
 	"github.com/unicitynetwork/bft-go-base/types"
 
+	"github.com/unicitynetwork/aggregator-go/internal/config"
 	"github.com/unicitynetwork/aggregator-go/internal/events"
 	"github.com/unicitynetwork/aggregator-go/internal/logger"
 	"github.com/unicitynetwork/aggregator-go/internal/models"
 	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
+
+func TestBFTClientStartFailureReturnsToIdleAndCanRetry(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	authSigner, err := abcrypto.NewInMemorySecp256K1Signer()
+	require.NoError(t, err)
+	authKey, err := authSigner.MarshalPrivateKey()
+	require.NoError(t, err)
+
+	client := &BFTClientImpl{
+		logger: log,
+		conf: &config.BFTConfig{
+			Address: "/ip4/127.0.0.1/tcp/0",
+			KeyConf: &cmdbft.KeyConf{
+				SigKey: cmdbft.Key{
+					Algorithm:  cmdbft.KeyAlgorithmSecp256k1,
+					PrivateKey: []byte{1},
+				},
+				AuthKey: cmdbft.Key{
+					Algorithm:  cmdbft.KeyAlgorithmSecp256k1,
+					PrivateKey: authKey,
+				},
+			},
+		},
+	}
+	client.status.Store(idle)
+
+	for range 2 {
+		err = client.Start(t.Context())
+		require.Error(t, err)
+		require.Equal(t, idle, client.status.Load().(status))
+		require.Nil(t, client.Peer())
+	}
+}
 
 type stubRoundManager struct {
 	finalizedBlocks        []*models.Block
@@ -24,11 +62,14 @@ type stubRoundManager struct {
 	startedRounds          []*api.BigInt
 	committedRoot          []byte
 	committedBlock         *api.BigInt
+	committedRootStarted   chan<- struct{}
+	committedRootRelease   <-chan struct{}
 	durableRecovered       bool
 	durableRecoveryBlock   *api.BigInt
 	durableRecoveryRoot    api.HexBytes
 	durableRecoveryCert    api.HexBytes
 	durableRecoveryCallCnt int
+	durableRecoveryErr     error
 	durableLoadedBlock     *models.Block
 	durableLoadFound       bool
 	durableLoadBlock       *api.BigInt
@@ -59,6 +100,12 @@ func (m *stubRoundManager) StartNextRoundFromPrecollector(ctx context.Context, r
 }
 
 func (m *stubRoundManager) CommittedRoot(context.Context) ([]byte, *api.BigInt, error) {
+	if m.committedRootStarted != nil {
+		m.committedRootStarted <- struct{}{}
+	}
+	if m.committedRootRelease != nil {
+		<-m.committedRootRelease
+	}
 	return m.committedRoot, m.committedBlock, nil
 }
 
@@ -67,7 +114,7 @@ func (m *stubRoundManager) FinalizeCertifiedProposal(_ context.Context, blockNum
 	m.durableRecoveryBlock = api.NewBigInt(new(big.Int).Set(blockNumber.Int))
 	m.durableRecoveryRoot = append(api.HexBytes(nil), rootHash...)
 	m.durableRecoveryCert = append(api.HexBytes(nil), unicityCertificate...)
-	return m.durableRecovered, nil
+	return m.durableRecovered, m.durableRecoveryErr
 }
 
 func (m *stubRoundManager) LoadDurableProposal(_ context.Context, blockNumber *api.BigInt) (*models.Block, bool, error) {
@@ -343,9 +390,11 @@ func TestBFTClientInitializationResendsDurableProposal(t *testing.T) {
 	require.Equal(t, 1, rm.durableLoadCallCnt)
 	require.EqualValues(t, 12, rm.durableLoadBlock.Uint64())
 	require.Empty(t, rm.startedRounds)
-	require.Same(t, proposal, client.proposedBlock)
-	require.True(t, client.resumedDurableProposal)
-	require.Equal(t, normal, client.status.Load().(status))
+	require.Nil(t, client.proposedBlock)
+	require.False(t, client.resumedDurableProposal)
+	require.Equal(t, initializing, client.status.Load().(status))
+	require.Nil(t, client.luc.Load())
+	require.Zero(t, client.nextExpectedRound.Load())
 }
 
 func TestBFTClientInitializationFinalizesCertifiedDurableProposalBeforeStartingNextRound(t *testing.T) {
@@ -383,92 +432,346 @@ func TestBFTClientInitializationFinalizesCertifiedDurableProposalBeforeStartingN
 	require.Equal(t, normal, client.status.Load().(status))
 }
 
-func TestBFTClientInitializationFinalizesMatchingInMemoryProposal(t *testing.T) {
+func TestBFTClientStopClearsSessionProposalState(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	client := &BFTClientImpl{
+		logger:                 log,
+		proposedBlock:          &models.Block{},
+		resumedDurableProposal: true,
+	}
+	client.status.Store(normal)
+	client.certRequestTime.Store(time.Now().UnixNano())
+
+	client.Stop()
+
+	require.Equal(t, idle, client.status.Load().(status))
+	require.Nil(t, client.proposedBlock)
+	require.False(t, client.resumedDurableProposal)
+	require.Zero(t, client.certRequestTime.Load())
+}
+
+func TestBFTClientStopWaitsForEventLoopExit(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	loopCanceled := make(chan struct{})
+	loopDone := make(chan struct{})
+	client := &BFTClientImpl{
+		logger:      log,
+		msgLoopDone: loopDone,
+		msgLoopCancelFn: func() {
+			close(loopCanceled)
+		},
+	}
+	client.status.Store(normal)
+
+	stopDone := make(chan struct{})
+	go func() {
+		client.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-loopCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not cancel the event loop")
+	}
+	select {
+	case <-stopDone:
+		t.Fatal("stop returned before the event loop exited")
+	default:
+	}
+	require.Equal(t, stopping, client.status.Load().(status))
+	require.ErrorIs(t, client.Start(t.Context()), ErrBFTClientStopping)
+
+	secondStopDone := make(chan struct{})
+	go func() {
+		client.Stop()
+		close(secondStopDone)
+	}()
+	select {
+	case <-secondStopDone:
+		t.Fatal("concurrent stop returned before the active stop completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(loopDone)
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not return after the event loop exited")
+	}
+	select {
+	case <-secondStopDone:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent stop did not join the active stop")
+	}
+	require.Equal(t, idle, client.status.Load().(status))
+}
+
+func TestBFTClientStopCancelsBeforeWaitingForUCProcessing(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	loopCtx, cancelLoop := context.WithCancel(context.Background())
+	client := &BFTClientImpl{
+		logger:          log,
+		msgLoopCancelFn: cancelLoop,
+	}
+	client.status.Store(normal)
+
+	processingStarted := make(chan struct{})
+	processingDone := make(chan struct{})
+	go func() {
+		client.ucProcessingMutex.Lock()
+		close(processingStarted)
+		<-loopCtx.Done()
+		client.ucProcessingMutex.Unlock()
+		close(processingDone)
+	}()
+	<-processingStarted
+
+	stopDone := make(chan struct{})
+	go func() {
+		client.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-processingDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not cancel UC processing before waiting for it")
+	}
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not return after UC processing exited")
+	}
+	require.Equal(t, idle, client.status.Load().(status))
+}
+
+func TestBFTClientInitializationCannotOverwriteStopping(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	root := bytes.Repeat([]byte{0x31}, api.SiblingSize)
+	committedRootStarted := make(chan struct{}, 1)
+	committedRootRelease := make(chan struct{})
+	rm := &stubRoundManager{
+		committedRoot:        root,
+		committedBlock:       api.NewBigIntFromUint64(11),
+		committedRootStarted: committedRootStarted,
+		committedRootRelease: committedRootRelease,
+	}
+	loopCanceled := make(chan struct{})
+	client := &BFTClientImpl{
+		logger:          log,
+		roundManager:    rm,
+		msgLoopCancelFn: func() { close(loopCanceled) },
+	}
+	client.status.Store(initializing)
+
+	handlerDone := make(chan error, 1)
+	go func() {
+		handlerDone <- client.handleUnicityCertificate(
+			context.Background(),
+			testUnicityCertificate(12, 21, root, root),
+			&certification.TechnicalRecord{Round: 13, Epoch: 1},
+		)
+	}()
+	<-committedRootStarted
+
+	stopDone := make(chan struct{})
+	go func() {
+		client.Stop()
+		close(stopDone)
+	}()
+	<-loopCanceled
+
+	// Hold mu after Stop publishes stopping, keeping Stop in cleanup while the
+	// initialization handler completes and attempts its status transition.
+	client.mu.Lock()
+	close(committedRootRelease)
+	require.NoError(t, <-handlerDone)
+	require.Equal(t, stopping, client.status.Load().(status))
+	client.mu.Unlock()
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not complete after initialization handler exited")
+	}
+	require.Equal(t, idle, client.status.Load().(status))
+}
+
+func TestBFTClientInitializationFailureRemainsRetryable(t *testing.T) {
 	log, err := logger.New("warn", "json", "", false)
 	require.NoError(t, err)
 
 	committedRoot := bytes.Repeat([]byte{0x10}, api.SiblingSize)
-	proposalRoot := api.NewHexBytes(bytes.Repeat([]byte{0x20}, api.SiblingSize))
-	proposal := models.NewBlock(
-		api.NewBigIntFromUint64(12),
-		"unicity",
-		0,
-		"1.0",
-		"mainnet",
-		proposalRoot,
-		api.NewHexBytes(committedRoot),
-		nil,
-	)
-	proposal.Status = models.FinalityStatusProposed
+	certifiedRoot := bytes.Repeat([]byte{0x20}, api.SiblingSize)
 	rm := &stubRoundManager{
-		committedRoot:  committedRoot,
-		committedBlock: api.NewBigIntFromUint64(11),
+		committedRoot:      committedRoot,
+		committedBlock:     api.NewBigIntFromUint64(120),
+		durableRecoveryErr: errors.New("temporary recovery failure"),
 	}
 	client := &BFTClientImpl{
-		logger:        log,
-		roundManager:  rm,
-		proposedBlock: proposal,
+		logger:       log,
+		roundManager: rm,
 	}
 	client.status.Store(initializing)
+	uc := testUnicityCertificate(121, 90, certifiedRoot, committedRoot)
+	tr := &certification.TechnicalRecord{Round: 123, Epoch: 1}
 
-	err = client.handleUnicityCertificate(
-		t.Context(),
-		testUnicityCertificate(12, 21, proposalRoot, committedRoot),
-		&certification.TechnicalRecord{Round: 13, Epoch: 1},
-	)
+	err = client.handleUnicityCertificate(t.Context(), uc, tr)
+	require.ErrorContains(t, err, "temporary recovery failure")
+	require.Equal(t, initializing, client.status.Load().(status))
+	require.Nil(t, client.luc.Load())
+	require.Zero(t, client.nextExpectedRound.Load())
 
-	require.NoError(t, err)
-	require.Equal(t, 1, rm.finalizeBlockCallCnt)
-	require.Len(t, rm.finalizedBlocks, 1)
-	require.Same(t, proposal, rm.finalizedBlocks[0])
-	require.NotEmpty(t, proposal.UnicityCertificate)
-	require.Zero(t, rm.durableRecoveryCallCnt)
-	require.Zero(t, rm.durableLoadCallCnt)
-	require.Len(t, rm.startedRounds, 1)
-	require.EqualValues(t, 13, rm.startedRounds[0].Uint64())
-	require.Nil(t, client.proposedBlock)
+	rm.durableRecoveryErr = nil
+	rm.durableRecovered = true
+	require.NoError(t, client.handleUnicityCertificate(t.Context(), uc, tr))
 	require.Equal(t, normal, client.status.Load().(status))
+	require.Equal(t, 2, rm.durableRecoveryCallCnt)
+	require.Len(t, rm.startedRounds, 1)
 }
 
-func TestBFTClientInitializationRejectsMatchingRoundRootMismatch(t *testing.T) {
+func TestBFTClientRetainedDuplicateUCCompletesInitialization(t *testing.T) {
 	log, err := logger.New("warn", "json", "", false)
 	require.NoError(t, err)
 
-	rm := &stubRoundManager{}
-	blockRoot := api.NewHexBytes(bytes.Repeat([]byte{0x11}, api.SiblingSize))
-	ucRoot := bytes.Repeat([]byte{0x22}, api.SiblingSize)
-	block := models.NewBlock(
-		api.NewBigIntFromUint64(7),
-		"unicity",
-		0,
-		"1.0",
-		"mainnet",
-		blockRoot,
-		nil,
-		nil,
-	)
+	root := bytes.Repeat([]byte{0x31}, api.SiblingSize)
+	retainedUC := testUnicityCertificate(10, 20, root, nil)
+	rm := &stubRoundManager{
+		committedRoot:  root,
+		committedBlock: api.NewBigIntFromUint64(10),
+	}
 	client := &BFTClientImpl{
-		logger:        log,
-		roundManager:  rm,
-		proposedBlock: block,
+		logger:       log,
+		roundManager: rm,
 	}
 	client.status.Store(initializing)
+	client.luc.Store(retainedUC)
+	client.lastRootRound.Store(retainedUC.GetRootRoundNumber())
 
-	err = client.handleUnicityCertificate(
+	require.NoError(t, client.handleUnicityCertificate(
 		t.Context(),
-		testUnicityCertificate(7, 8, ucRoot, nil),
-		&certification.TechnicalRecord{Round: 8},
+		retainedUC,
+		&certification.TechnicalRecord{Round: 11, Epoch: 1},
+	))
+
+	require.Equal(t, normal, client.status.Load().(status))
+	require.Len(t, rm.startedRounds, 1)
+	require.EqualValues(t, 11, rm.startedRounds[0].Uint64())
+}
+
+func TestBFTClientRepeatUCCompletesInitialization(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	root := bytes.Repeat([]byte{0x32}, api.SiblingSize)
+	previousUC := testUnicityCertificate(10, 20, root, nil)
+	repeatUC := testUnicityCertificate(10, 21, root, previousUC.InputRecord.PreviousHash)
+	rm := &stubRoundManager{}
+	client := &BFTClientImpl{
+		logger:       log,
+		roundManager: rm,
+	}
+	client.status.Store(initializing)
+	client.luc.Store(previousUC)
+	client.lastRootRound.Store(previousUC.GetRootRoundNumber())
+
+	require.NoError(t, client.handleUnicityCertificate(
+		t.Context(),
+		repeatUC,
+		&certification.TechnicalRecord{Round: 12, Epoch: 1},
+	))
+
+	require.Equal(t, normal, client.status.Load().(status))
+	require.Same(t, repeatUC, client.luc.Load())
+	require.Len(t, rm.startedRounds, 1)
+	require.EqualValues(t, 12, rm.startedRounds[0].Uint64())
+}
+
+func TestBFTClientCanceledFinalizationDoesNotPublishFatal(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+	eventBus := events.NewEventBus(log)
+	fatalEvents := eventBus.Subscribe(events.TopicFatalError)
+	client := &BFTClientImpl{logger: log, eventBus: eventBus}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client.publishFatalError(ctx, context.Canceled)
+
+	select {
+	case event := <-fatalEvents:
+		t.Fatalf("unexpected fatal event during intentional cancellation: %#v", event)
+	default:
+	}
+}
+
+func TestBFTClientCancellationDoesNotHideUnrelatedFatalError(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+	eventBus := events.NewEventBus(log)
+	fatalEvents := eventBus.Subscribe(events.TopicFatalError)
+	client := &BFTClientImpl{logger: log, eventBus: eventBus}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	corruptionErr := errors.New("certified root mismatch")
+	client.publishFatalError(ctx, corruptionErr)
+
+	select {
+	case event := <-fatalEvents:
+		fatal, ok := event.(events.FatalErrorEvent)
+		require.True(t, ok)
+		require.Equal(t, corruptionErr.Error(), fatal.Error)
+	default:
+		t.Fatal("expected unrelated fatal error to remain visible after cancellation")
+	}
+}
+
+func TestBFTClientCanceledSessionDoesNotProcessBufferedUC(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	previousUC := testUnicityCertificate(10, 20, bytes.Repeat([]byte{0x10}, api.SiblingSize), nil)
+	client := &BFTClientImpl{
+		logger:       log,
+		roundManager: &stubRoundManager{},
+	}
+	client.luc.Store(previousUC)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = client.handleUnicityCertificate(
+		ctx,
+		testUnicityCertificate(11, 21, bytes.Repeat([]byte{0x11}, api.SiblingSize), previousUC.InputRecord.Hash),
+		&certification.TechnicalRecord{Round: 12, Epoch: 1},
 	)
 
-	require.ErrorIs(t, err, ErrCertifiedRootMismatch)
-	require.Empty(t, rm.finalizedBlocks)
-	require.Nil(t, client.proposedBlock)
-	require.Empty(t, block.UnicityCertificate)
-	require.Equal(t, 1, rm.durableAbandonCallCnt)
-	require.True(t, bytes.Equal(blockRoot, rm.durableAbandonRoot))
-	require.Zero(t, rm.durableRecoveryCallCnt)
-	require.Zero(t, rm.durableLoadCallCnt)
-	require.Equal(t, normal, client.status.Load().(status))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Same(t, previousUC, client.luc.Load())
+}
+
+func TestBFTClientRetainedUCDoesNotBypassInitialization(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	client := &BFTClientImpl{logger: log}
+	client.status.Store(initializing)
+	client.luc.Store(testUnicityCertificate(10, 20, bytes.Repeat([]byte{0x10}, api.SiblingSize), nil))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err = client.ensureInitialized(ctx)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestBFTClientInitializationStartsRoundWhenNoDurableProposal(t *testing.T) {

--- a/internal/bft/client_stub_test.go
+++ b/internal/bft/client_stub_test.go
@@ -383,6 +383,94 @@ func TestBFTClientInitializationFinalizesCertifiedDurableProposalBeforeStartingN
 	require.Equal(t, normal, client.status.Load().(status))
 }
 
+func TestBFTClientInitializationFinalizesMatchingInMemoryProposal(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	committedRoot := bytes.Repeat([]byte{0x10}, api.SiblingSize)
+	proposalRoot := api.NewHexBytes(bytes.Repeat([]byte{0x20}, api.SiblingSize))
+	proposal := models.NewBlock(
+		api.NewBigIntFromUint64(12),
+		"unicity",
+		0,
+		"1.0",
+		"mainnet",
+		proposalRoot,
+		api.NewHexBytes(committedRoot),
+		nil,
+	)
+	proposal.Status = models.FinalityStatusProposed
+	rm := &stubRoundManager{
+		committedRoot:  committedRoot,
+		committedBlock: api.NewBigIntFromUint64(11),
+	}
+	client := &BFTClientImpl{
+		logger:        log,
+		roundManager:  rm,
+		proposedBlock: proposal,
+	}
+	client.status.Store(initializing)
+
+	err = client.handleUnicityCertificate(
+		t.Context(),
+		testUnicityCertificate(12, 21, proposalRoot, committedRoot),
+		&certification.TechnicalRecord{Round: 13, Epoch: 1},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, rm.finalizeBlockCallCnt)
+	require.Len(t, rm.finalizedBlocks, 1)
+	require.Same(t, proposal, rm.finalizedBlocks[0])
+	require.NotEmpty(t, proposal.UnicityCertificate)
+	require.Zero(t, rm.durableRecoveryCallCnt)
+	require.Zero(t, rm.durableLoadCallCnt)
+	require.Len(t, rm.startedRounds, 1)
+	require.EqualValues(t, 13, rm.startedRounds[0].Uint64())
+	require.Nil(t, client.proposedBlock)
+	require.Equal(t, normal, client.status.Load().(status))
+}
+
+func TestBFTClientInitializationRejectsMatchingRoundRootMismatch(t *testing.T) {
+	log, err := logger.New("warn", "json", "", false)
+	require.NoError(t, err)
+
+	rm := &stubRoundManager{}
+	blockRoot := api.NewHexBytes(bytes.Repeat([]byte{0x11}, api.SiblingSize))
+	ucRoot := bytes.Repeat([]byte{0x22}, api.SiblingSize)
+	block := models.NewBlock(
+		api.NewBigIntFromUint64(7),
+		"unicity",
+		0,
+		"1.0",
+		"mainnet",
+		blockRoot,
+		nil,
+		nil,
+	)
+	client := &BFTClientImpl{
+		logger:        log,
+		roundManager:  rm,
+		proposedBlock: block,
+	}
+	client.status.Store(initializing)
+
+	err = client.handleUnicityCertificate(
+		t.Context(),
+		testUnicityCertificate(7, 8, ucRoot, nil),
+		&certification.TechnicalRecord{Round: 8},
+	)
+
+	require.ErrorIs(t, err, ErrCertifiedRootMismatch)
+	require.Empty(t, rm.finalizedBlocks)
+	require.Nil(t, client.proposedBlock)
+	require.Empty(t, block.UnicityCertificate)
+	require.Equal(t, 1, rm.durableAbandonCallCnt)
+	require.True(t, bytes.Equal(blockRoot, rm.durableAbandonRoot))
+	require.Zero(t, rm.durableRecoveryCallCnt)
+	require.Zero(t, rm.durableLoadCallCnt)
+	require.Equal(t, normal, client.status.Load().(status))
+}
+
 func TestBFTClientInitializationStartsRoundWhenNoDurableProposal(t *testing.T) {
 	log, err := logger.New("warn", "json", "", false)
 	require.NoError(t, err)

--- a/internal/round/batch_processor.go
+++ b/internal/round/batch_processor.go
@@ -532,17 +532,23 @@ func (rm *RoundManager) reconcileRecoveredFinalization(ctx context.Context, reco
 		if err := rm.syncDiskSMTAfterRecoveredBlock(ctx, recoveryResult); err != nil {
 			return err
 		}
-		rm.clearProofPending()
-		return nil
-	}
-
-	if snapshot != nil {
+	} else if snapshot != nil {
 		if err := snapshot.Commit(ctx, smtbackend.CommitMetadata{BlockNumber: blockNumber}); err != nil {
 			return fmt.Errorf("failed to commit recovered SMT snapshot: %w", err)
 		}
 	}
 
-	rm.clearProofPending()
+	rm.roundMutex.Lock()
+	if blockNumber != nil &&
+		recoveryResult.Block != nil &&
+		rm.currentRound != nil &&
+		rm.currentRound.Number != nil &&
+		rm.currentRound.Number.Cmp(blockNumber.Int) == 0 {
+		rm.currentRound.Block = recoveryResult.Block
+	}
+	rm.roundMutex.Unlock()
+
+	rm.clearProofStateIDsPending(recoveryResult.StateIDs)
 	return nil
 }
 

--- a/internal/round/precollection_test.go
+++ b/internal/round/precollection_test.go
@@ -330,7 +330,7 @@ func TestProcessMiniBatch_SkipsExistingDuplicateWithoutProofPending(t *testing.T
 	require.True(t, newPending)
 }
 
-func TestReconcileRecoveredFinalization_CommitsMatchingSnapshotAndClearsProofPending(t *testing.T) {
+func TestReconcileRecoveredFinalization_CommitsMatchingSnapshotAndMarksRoundFinalized(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.Config{
 		Processing: config.ProcessingConfig{
@@ -369,7 +369,19 @@ func TestReconcileRecoveredFinalization_CommitsMatchingSnapshotAndClearsProofPen
 	rm.proofCacheMu.RUnlock()
 	require.True(t, pendingBefore)
 
-	err = rm.reconcileRecoveredFinalization(ctx, &RecoveryResult{Recovered: true, BlockNumber: blockNumber})
+	nextRoundCommitment := testutil.CreateTestCertificationRequest(t, "next_round_pending")
+	rm.markProofsPending([]*models.CertificationRequest{nextRoundCommitment})
+	recoveredBlock := &models.Block{
+		Index:     blockNumber,
+		Finalized: true,
+		Status:    models.FinalityStatusFinalized,
+	}
+	err = rm.reconcileRecoveredFinalization(ctx, &RecoveryResult{
+		Recovered:   true,
+		BlockNumber: blockNumber,
+		Block:       recoveredBlock,
+		StateIDs:    []api.StateID{commitment.StateID},
+	})
 	require.NoError(t, err)
 
 	_, err = smtInstance.GetInclusionCert(key)
@@ -377,11 +389,14 @@ func TestReconcileRecoveredFinalization_CommitsMatchingSnapshotAndClearsProofPen
 
 	rm.proofCacheMu.RLock()
 	_, pendingAfter := rm.proofPending[commitment.StateID.String()]
+	_, nextRoundPending := rm.proofPending[nextRoundCommitment.StateID.String()]
 	rm.proofCacheMu.RUnlock()
 	require.False(t, pendingAfter)
+	require.True(t, nextRoundPending)
+	require.Same(t, recoveredBlock, rm.currentRound.Block)
 }
 
-func TestReconcileRecoveredFinalization_MismatchedBlockClearsProofPendingOnly(t *testing.T) {
+func TestReconcileRecoveredFinalization_MismatchedBlockClearsOnlyRecoveredProofPending(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.Config{
 		Processing: config.ProcessingConfig{
@@ -417,7 +432,18 @@ func TestReconcileRecoveredFinalization_MismatchedBlockClearsProofPendingOnly(t 
 	rm.proofCacheMu.RUnlock()
 	require.True(t, pendingBefore)
 
-	err = rm.reconcileRecoveredFinalization(ctx, &RecoveryResult{Recovered: true, BlockNumber: recoveredBlockNumber})
+	recoveredCommitment := testutil.CreateTestCertificationRequest(t, "recovered_previous_round")
+	rm.markProofsPending([]*models.CertificationRequest{recoveredCommitment})
+	err = rm.reconcileRecoveredFinalization(ctx, &RecoveryResult{
+		Recovered:   true,
+		BlockNumber: recoveredBlockNumber,
+		Block: &models.Block{
+			Index:     recoveredBlockNumber,
+			Finalized: true,
+			Status:    models.FinalityStatusFinalized,
+		},
+		StateIDs: []api.StateID{recoveredCommitment.StateID},
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, originalRoot, smtInstance.GetRootHash())
@@ -428,8 +454,11 @@ func TestReconcileRecoveredFinalization_MismatchedBlockClearsProofPendingOnly(t 
 
 	rm.proofCacheMu.RLock()
 	_, pendingAfter := rm.proofPending[commitment.StateID.String()]
+	_, recoveredPending := rm.proofPending[recoveredCommitment.StateID.String()]
 	rm.proofCacheMu.RUnlock()
-	require.False(t, pendingAfter)
+	require.True(t, pendingAfter)
+	require.False(t, recoveredPending)
+	require.Nil(t, rm.currentRound.Block)
 }
 
 // --- Tests for childPrecollector ---

--- a/internal/round/recovery.go
+++ b/internal/round/recovery.go
@@ -16,6 +16,7 @@ import (
 type RecoveryResult struct {
 	Recovered   bool
 	BlockNumber *api.BigInt
+	Block       *models.Block
 	StateIDs    []api.StateID
 }
 
@@ -270,11 +271,14 @@ func recoverUnfinalizedBlock(
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover block %s: %w", block.Index.String(), err)
 	}
+	block.Finalized = true
+	block.Status = models.FinalityStatusFinalized
 
 	log.WithContext(ctx).Info("Block recovery completed successfully", "blockNumber", block.Index.String())
 	return &RecoveryResult{
 		Recovered:   true,
 		BlockNumber: block.Index,
+		Block:       block,
 		StateIDs:    stateIDs,
 	}, nil
 }

--- a/internal/round/round_manager.go
+++ b/internal/round/round_manager.go
@@ -38,6 +38,10 @@ const (
 
 const defaultMiniBatchSize = 500 // Number of commitments to process per SMT mini-batch
 
+type pendingSweepResetter interface {
+	ResetPendingSweep()
+}
+
 func (rs RoundState) String() string {
 	switch rs {
 	case RoundStateCollecting:
@@ -532,7 +536,7 @@ func (rm *RoundManager) StartNewRound(ctx context.Context, roundNumber *api.BigI
 	abandonPendingRound := rm.hasPendingRoundToAbandon(roundNumber)
 	if abandonPendingRound {
 		rm.roundMutex.Lock()
-		supersededSnapshot := rm.abandonSupersededRoundLocked(roundNumber)
+		supersededSnapshot, _ := rm.abandonSupersededRoundLocked(roundNumber)
 		rm.roundMutex.Unlock()
 		if supersededSnapshot != nil {
 			supersededSnapshot.Discard(ctx)
@@ -656,7 +660,11 @@ func (rm *RoundManager) StartNewRoundWithSnapshot(
 		leaves = make([]smtbackend.LeafInput, 0)
 	}
 
-	supersededSnapshot := rm.abandonSupersededRoundLocked(roundNumber)
+	supersededSnapshot, resetPendingSweep := rm.abandonSupersededRoundLocked(roundNumber)
+	if resetPendingSweep {
+		rm.clearProofPending()
+		rm.requestRedisPendingReplay()
+	}
 	processCtx, processCancel := context.WithCancel(roundCtx)
 	if proposalID == "" {
 		proposalID = uuid.NewString()
@@ -775,16 +783,18 @@ func (rm *RoundManager) retryRoundProposal(ctx context.Context, round *Round) er
 // superseded by a newer one and returns its unproposed snapshot (or nil) for the
 // caller to discard after releasing roundMutex. Proof-pending markers are cleared
 // separately via clearProofPending() at the abandon/deactivate/reset points.
-func (rm *RoundManager) abandonSupersededRoundLocked(roundNumber *api.BigInt) smtbackend.Snapshot {
+func (rm *RoundManager) abandonSupersededRoundLocked(roundNumber *api.BigInt) (smtbackend.Snapshot, bool) {
 	if rm.currentRound == nil {
-		return nil
+		return nil, false
 	}
 	if roundNumber == nil ||
 		roundNumber.Int == nil ||
 		rm.currentRound.Number == nil ||
 		rm.currentRound.Number.Cmp(roundNumber.Int) >= 0 {
-		return nil
+		return nil, false
 	}
+	resetPendingSweep := len(rm.currentRound.PendingCommitments) > 0 ||
+		(rm.currentRound.Snapshot != nil && len(rm.currentRound.Commitments) > 0)
 	if rm.currentRound.Cancel != nil {
 		rm.currentRound.Cancel()
 		rm.currentRound.Cancel = nil
@@ -795,7 +805,7 @@ func (rm *RoundManager) abandonSupersededRoundLocked(roundNumber *api.BigInt) sm
 	rm.currentRound.PendingRootHash = nil
 	rm.currentRound.PendingLeaves = nil
 	rm.currentRound.PendingCommitments = nil
-	return superseded
+	return superseded, resetPendingSweep
 }
 
 func (rm *RoundManager) processRound(ctx context.Context, round *Round) error {
@@ -1422,7 +1432,7 @@ func (rm *RoundManager) discardActivePrecollector(ctx context.Context) bool {
 }
 
 func (rm *RoundManager) resetRedisPendingSweep(ctx context.Context) {
-	cs, ok := rm.commitmentQueue.(*redis.CommitmentStorage)
+	cs, ok := rm.commitmentQueue.(pendingSweepResetter)
 	if !ok {
 		return
 	}
@@ -1433,6 +1443,14 @@ func (rm *RoundManager) resetRedisPendingSweep(ctx context.Context) {
 	if restartPrefetcher {
 		rm.startCommitmentPrefetcher(ctx)
 	}
+}
+
+func (rm *RoundManager) requestRedisPendingReplay() {
+	cs, ok := rm.commitmentQueue.(pendingSweepResetter)
+	if !ok {
+		return
+	}
+	cs.ResetPendingSweep()
 }
 
 func (rm *RoundManager) drainCommitmentStream() int {

--- a/internal/round/round_manager.go
+++ b/internal/round/round_manager.go
@@ -507,6 +507,32 @@ func (rm *RoundManager) clearProofPending() {
 	rm.proofPending = make(map[string]struct{})
 }
 
+func (rm *RoundManager) clearProofsPending(commitments []*models.CertificationRequest) {
+	if len(commitments) == 0 {
+		return
+	}
+
+	rm.proofCacheMu.Lock()
+	defer rm.proofCacheMu.Unlock()
+	for _, commitment := range commitments {
+		if commitment != nil {
+			delete(rm.proofPending, commitment.StateID.String())
+		}
+	}
+}
+
+func (rm *RoundManager) clearProofStateIDsPending(stateIDs []api.StateID) {
+	if len(stateIDs) == 0 {
+		return
+	}
+
+	rm.proofCacheMu.Lock()
+	defer rm.proofCacheMu.Unlock()
+	for _, stateID := range stateIDs {
+		delete(rm.proofPending, stateID.String())
+	}
+}
+
 // GetStats returns round manager statistics
 func (rm *RoundManager) GetStats() map[string]interface{} {
 	rm.roundMutex.RLock()
@@ -533,34 +559,20 @@ func (rm *RoundManager) GetStats() map[string]interface{} {
 
 // StartNewRound starts a new round for processing commitments (delegates to unified function)
 func (rm *RoundManager) StartNewRound(ctx context.Context, roundNumber *api.BigInt) error {
-	abandonPendingRound := rm.hasPendingRoundToAbandon(roundNumber)
-	if abandonPendingRound {
-		rm.roundMutex.Lock()
-		supersededSnapshot, _ := rm.abandonSupersededRoundLocked(roundNumber)
-		rm.roundMutex.Unlock()
-		if supersededSnapshot != nil {
-			supersededSnapshot.Discard(ctx)
-		}
+	rm.roundMutex.Lock()
+	supersededSnapshot, resetPendingSweep, unresolved := rm.abandonSupersededRoundLocked(roundNumber)
+	rm.roundMutex.Unlock()
+	if supersededSnapshot != nil {
+		supersededSnapshot.Discard(ctx)
+	}
+	if unresolved {
 		resetDone := rm.discardActivePrecollector(ctx)
-		if !resetDone {
+		if resetPendingSweep && !resetDone {
 			rm.clearProofPending()
 			rm.resetRedisPendingSweep(ctx)
 		}
 	}
 	return rm.StartNewRoundWithSnapshot(ctx, roundNumber, nil, nil, nil, false, "")
-}
-
-func (rm *RoundManager) hasPendingRoundToAbandon(roundNumber *api.BigInt) bool {
-	if roundNumber == nil || roundNumber.Int == nil {
-		return false
-	}
-
-	rm.roundMutex.RLock()
-	defer rm.roundMutex.RUnlock()
-	return rm.currentRound != nil &&
-		rm.currentRound.Number != nil &&
-		rm.currentRound.Number.Cmp(roundNumber.Int) < 0 &&
-		rm.currentRound.Snapshot != nil
 }
 
 // StartNewRoundWithSnapshot starts a new round, optionally with pre-collected data.
@@ -660,10 +672,9 @@ func (rm *RoundManager) StartNewRoundWithSnapshot(
 		leaves = make([]smtbackend.LeafInput, 0)
 	}
 
-	supersededSnapshot, resetPendingSweep := rm.abandonSupersededRoundLocked(roundNumber)
+	supersededSnapshot, resetPendingSweep, _ := rm.abandonSupersededRoundLocked(roundNumber)
 	if resetPendingSweep {
-		rm.clearProofPending()
-		rm.requestRedisPendingReplay()
+		rm.signalRedisPendingSweepReset()
 	}
 	processCtx, processCancel := context.WithCancel(roundCtx)
 	if proposalID == "" {
@@ -781,20 +792,25 @@ func (rm *RoundManager) retryRoundProposal(ctx context.Context, round *Round) er
 
 // abandonSupersededRoundLocked cancels the current round when it is being
 // superseded by a newer one and returns its unproposed snapshot (or nil) for the
-// caller to discard after releasing roundMutex. Proof-pending markers are cleared
-// separately via clearProofPending() at the abandon/deactivate/reset points.
-func (rm *RoundManager) abandonSupersededRoundLocked(roundNumber *api.BigInt) (smtbackend.Snapshot, bool) {
+// caller to discard after releasing roundMutex. Proof-pending markers owned by
+// unresolved superseded commitments are removed without disturbing newer markers.
+func (rm *RoundManager) abandonSupersededRoundLocked(roundNumber *api.BigInt) (smtbackend.Snapshot, bool, bool) {
 	if rm.currentRound == nil {
-		return nil, false
+		return nil, false, false
 	}
 	if roundNumber == nil ||
 		roundNumber.Int == nil ||
 		rm.currentRound.Number == nil ||
 		rm.currentRound.Number.Cmp(roundNumber.Int) >= 0 {
-		return nil, false
+		return nil, false, false
 	}
-	resetPendingSweep := len(rm.currentRound.PendingCommitments) > 0 ||
-		(rm.currentRound.Snapshot != nil && len(rm.currentRound.Commitments) > 0)
+	unresolved := rm.currentRound.Block == nil
+	resetPendingSweep := unresolved &&
+		(len(rm.currentRound.PendingCommitments) > 0 || len(rm.currentRound.Commitments) > 0)
+	if resetPendingSweep {
+		rm.clearProofsPending(rm.currentRound.Commitments)
+		rm.clearProofsPending(rm.currentRound.PendingCommitments)
+	}
 	if rm.currentRound.Cancel != nil {
 		rm.currentRound.Cancel()
 		rm.currentRound.Cancel = nil
@@ -805,7 +821,8 @@ func (rm *RoundManager) abandonSupersededRoundLocked(roundNumber *api.BigInt) (s
 	rm.currentRound.PendingRootHash = nil
 	rm.currentRound.PendingLeaves = nil
 	rm.currentRound.PendingCommitments = nil
-	return superseded, resetPendingSweep
+	rm.currentRound = nil
+	return superseded, resetPendingSweep, unresolved
 }
 
 func (rm *RoundManager) processRound(ctx context.Context, round *Round) error {
@@ -1445,7 +1462,10 @@ func (rm *RoundManager) resetRedisPendingSweep(ctx context.Context) {
 	}
 }
 
-func (rm *RoundManager) requestRedisPendingReplay() {
+// signalRedisPendingSweepReset only resets the Redis PEL cursor. This path runs
+// under roundMutex and already owns the incoming precollected batch, so it must
+// not stop or drain the shared commitment prefetcher.
+func (rm *RoundManager) signalRedisPendingSweepReset() {
 	cs, ok := rm.commitmentQueue.(pendingSweepResetter)
 	if !ok {
 		return

--- a/internal/round/round_process_regression_test.go
+++ b/internal/round/round_process_regression_test.go
@@ -317,7 +317,7 @@ func (q *resetRecordingCommitmentQueue) ResetPendingSweep() {
 	q.resetCount++
 }
 
-func TestStartNewRoundWithSnapshotAbandonResetsRedisPendingSweep(t *testing.T) {
+func TestStartNewRoundWithSnapshotAbandonAfterSnapshotCleanupResetsRedisPendingSweep(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	cfg := config.Config{
@@ -359,14 +359,14 @@ func TestStartNewRoundWithSnapshotAbandonResetsRedisPendingSweep(t *testing.T) {
 
 	oldCommitment := testutil.CreateTestCertificationRequest(t, "abandoned_precollected_round")
 	oldCtx, oldCancel := context.WithCancel(ctx)
-	oldSnapshot := &discardCountingSnapshot{Snapshot: testRMSnapshot(t, ctx, rm)}
 	rm.currentRound = &Round{
-		Number:             api.NewBigInt(big.NewInt(1)),
-		StartTime:          time.Now(),
-		State:              RoundStateProcessing,
-		Commitments:        []*models.CertificationRequest{oldCommitment},
-		Cancel:             oldCancel,
-		Snapshot:           oldSnapshot,
+		Number:      api.NewBigInt(big.NewInt(1)),
+		StartTime:   time.Now(),
+		State:       RoundStateProcessing,
+		Commitments: []*models.CertificationRequest{oldCommitment},
+		Cancel:      oldCancel,
+		// processRound clears Snapshot when cancellation wins before proposal.
+		Snapshot:           nil,
 		PendingCommitments: []*models.CertificationRequest{oldCommitment},
 	}
 	rm.markProofsPending([]*models.CertificationRequest{oldCommitment})
@@ -379,6 +379,7 @@ func TestStartNewRoundWithSnapshotAbandonResetsRedisPendingSweep(t *testing.T) {
 	result, err := newSnapshot.AddLeavesClassified(ctx, []smtbackend.LeafInput{newLeaf})
 	require.NoError(t, err)
 	require.NoError(t, result.ValidateAllAccepted(1))
+	rm.markProofsPending([]*models.CertificationRequest{newCommitment})
 
 	require.NoError(t, rm.StartNewRoundWithSnapshot(
 		ctx,
@@ -390,7 +391,6 @@ func TestStartNewRoundWithSnapshotAbandonResetsRedisPendingSweep(t *testing.T) {
 		"",
 	))
 
-	require.Equal(t, 1, oldSnapshot.discards)
 	require.Equal(t, 1, resetQueue.resetCount)
 	select {
 	case <-oldCtx.Done():
@@ -399,6 +399,8 @@ func TestStartNewRoundWithSnapshotAbandonResetsRedisPendingSweep(t *testing.T) {
 	}
 	_, pending := rm.proofPending[oldCommitment.StateID.String()]
 	require.False(t, pending)
+	_, pending = rm.proofPending[newCommitment.StateID.String()]
+	require.True(t, pending)
 }
 
 func TestStartNewRoundWithSnapshotDoesNotReplayFinalizedRoundHistory(t *testing.T) {
@@ -447,9 +449,10 @@ func TestStartNewRoundWithSnapshotDoesNotReplayFinalizedRoundHistory(t *testing.
 		StartTime:   time.Now(),
 		State:       RoundStateFinalizing,
 		Commitments: []*models.CertificationRequest{oldCommitment},
+		Block:       &models.Block{},
 		Snapshot:    nil,
 		// A normally finalized round has historical Commitments left for
-		// diagnostics, but no unresolved snapshot or pending commitments.
+		// diagnostics, but Block is set and unresolved state is cleared.
 		PendingCommitments: nil,
 	}
 

--- a/internal/round/round_process_regression_test.go
+++ b/internal/round/round_process_regression_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/unicitynetwork/aggregator-go/internal/models"
 	"github.com/unicitynetwork/aggregator-go/internal/smt"
 	smtbackend "github.com/unicitynetwork/aggregator-go/internal/smt/backend"
+	"github.com/unicitynetwork/aggregator-go/internal/storage/interfaces"
 	"github.com/unicitynetwork/aggregator-go/internal/testutil"
 	"github.com/unicitynetwork/aggregator-go/pkg/api"
 )
@@ -254,6 +255,227 @@ func TestStartNewRoundAbandonsSupersededPendingRound(t *testing.T) {
 
 	_, pending := rm.proofPending[commitment.StateID.String()]
 	require.False(t, pending)
+}
+
+type resetRecordingCommitmentQueue struct {
+	resetCount int
+}
+
+func (q *resetRecordingCommitmentQueue) Store(context.Context, *models.CertificationRequest) error {
+	return nil
+}
+
+func (q *resetRecordingCommitmentQueue) GetByStateID(context.Context, api.StateID) (*models.CertificationRequest, error) {
+	return nil, nil
+}
+
+func (q *resetRecordingCommitmentQueue) GetUnprocessedBatch(context.Context, int) ([]*models.CertificationRequest, error) {
+	return nil, nil
+}
+
+func (q *resetRecordingCommitmentQueue) GetUnprocessedBatchWithCursor(context.Context, string, int) ([]*models.CertificationRequest, string, error) {
+	return nil, "", nil
+}
+
+func (q *resetRecordingCommitmentQueue) StreamCertificationRequests(context.Context, chan<- *models.CertificationRequest) error {
+	return nil
+}
+
+func (q *resetRecordingCommitmentQueue) MarkProcessed(context.Context, []interfaces.CertificationRequestAck) error {
+	return nil
+}
+
+func (q *resetRecordingCommitmentQueue) Delete(context.Context, []api.StateID) error {
+	return nil
+}
+
+func (q *resetRecordingCommitmentQueue) Count(context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (q *resetRecordingCommitmentQueue) CountUnprocessed(context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (q *resetRecordingCommitmentQueue) GetAllPending(context.Context) ([]*models.CertificationRequest, error) {
+	return nil, nil
+}
+
+func (q *resetRecordingCommitmentQueue) GetByStateIDs(context.Context, []api.StateID) (map[string]*models.CertificationRequest, error) {
+	return nil, nil
+}
+
+func (q *resetRecordingCommitmentQueue) Initialize(context.Context) error {
+	return nil
+}
+
+func (q *resetRecordingCommitmentQueue) Close(context.Context) error {
+	return nil
+}
+
+func (q *resetRecordingCommitmentQueue) ResetPendingSweep() {
+	q.resetCount++
+}
+
+func TestStartNewRoundWithSnapshotAbandonResetsRedisPendingSweep(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cfg := config.Config{
+		Database: config.DatabaseConfig{
+			Database: "test_start_round_snapshot_abandon_resets_pending_sweep",
+		},
+		Processing: config.ProcessingConfig{
+			CollectPhaseDuration:       time.Hour,
+			CommitmentStreamBufferSize: 16,
+			MaxCommitmentsPerRound:     1000,
+		},
+		Storage:  config.StorageConfig{UseRedisForCommitments: true},
+		Sharding: config.ShardingConfig{Mode: config.ShardingModeBFTShard},
+	}
+	storage := testutil.SetupTestStorage(t, cfg)
+	testLogger := newTestLogger(t)
+	threadSafeSMT := smt.NewThreadSafeSMT(smt.NewSparseMerkleTree(api.SHA256, api.StateTreeKeyLengthBits))
+	rm, err := NewRoundManager(
+		ctx,
+		&cfg,
+		testLogger,
+		storage.CommitmentQueue(),
+		storage,
+		nil,
+		state.NewSyncStateTracker(),
+		nil,
+		events.NewEventBus(testLogger),
+		threadSafeSMT,
+		nil,
+	)
+	require.NoError(t, err)
+	resetQueue := &resetRecordingCommitmentQueue{}
+	rm.commitmentQueue = resetQueue
+	rm.bftClient = newRecordingBFTClient()
+	defer func() {
+		cancel()
+		rm.roundWG.Wait()
+	}()
+
+	oldCommitment := testutil.CreateTestCertificationRequest(t, "abandoned_precollected_round")
+	oldCtx, oldCancel := context.WithCancel(ctx)
+	oldSnapshot := &discardCountingSnapshot{Snapshot: testRMSnapshot(t, ctx, rm)}
+	rm.currentRound = &Round{
+		Number:             api.NewBigInt(big.NewInt(1)),
+		StartTime:          time.Now(),
+		State:              RoundStateProcessing,
+		Commitments:        []*models.CertificationRequest{oldCommitment},
+		Cancel:             oldCancel,
+		Snapshot:           oldSnapshot,
+		PendingCommitments: []*models.CertificationRequest{oldCommitment},
+	}
+	rm.markProofsPending([]*models.CertificationRequest{oldCommitment})
+
+	newCommitment := testutil.CreateTestCertificationRequest(t, "new_precollected_round")
+	newLeaf, err := commitmentLeafInput(newCommitment)
+	require.NoError(t, err)
+	newSnapshot, err := rm.smtBackend.CreateSnapshot(ctx)
+	require.NoError(t, err)
+	result, err := newSnapshot.AddLeavesClassified(ctx, []smtbackend.LeafInput{newLeaf})
+	require.NoError(t, err)
+	require.NoError(t, result.ValidateAllAccepted(1))
+
+	require.NoError(t, rm.StartNewRoundWithSnapshot(
+		ctx,
+		api.NewBigInt(big.NewInt(2)),
+		newSnapshot,
+		[]*models.CertificationRequest{newCommitment},
+		[]smtbackend.LeafInput{newLeaf},
+		false,
+		"",
+	))
+
+	require.Equal(t, 1, oldSnapshot.discards)
+	require.Equal(t, 1, resetQueue.resetCount)
+	select {
+	case <-oldCtx.Done():
+	default:
+		t.Fatal("superseded round context was not cancelled")
+	}
+	_, pending := rm.proofPending[oldCommitment.StateID.String()]
+	require.False(t, pending)
+}
+
+func TestStartNewRoundWithSnapshotDoesNotReplayFinalizedRoundHistory(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cfg := config.Config{
+		Database: config.DatabaseConfig{
+			Database: "test_start_round_snapshot_no_replay_finalized_history",
+		},
+		Processing: config.ProcessingConfig{
+			CollectPhaseDuration:       time.Hour,
+			CommitmentStreamBufferSize: 16,
+			MaxCommitmentsPerRound:     1000,
+		},
+		Storage:  config.StorageConfig{UseRedisForCommitments: true},
+		Sharding: config.ShardingConfig{Mode: config.ShardingModeBFTShard},
+	}
+	storage := testutil.SetupTestStorage(t, cfg)
+	testLogger := newTestLogger(t)
+	threadSafeSMT := smt.NewThreadSafeSMT(smt.NewSparseMerkleTree(api.SHA256, api.StateTreeKeyLengthBits))
+	rm, err := NewRoundManager(
+		ctx,
+		&cfg,
+		testLogger,
+		storage.CommitmentQueue(),
+		storage,
+		nil,
+		state.NewSyncStateTracker(),
+		nil,
+		events.NewEventBus(testLogger),
+		threadSafeSMT,
+		nil,
+	)
+	require.NoError(t, err)
+	resetQueue := &resetRecordingCommitmentQueue{}
+	rm.commitmentQueue = resetQueue
+	rm.bftClient = newRecordingBFTClient()
+	defer func() {
+		cancel()
+		rm.roundWG.Wait()
+	}()
+
+	oldCommitment := testutil.CreateTestCertificationRequest(t, "finalized_round_history")
+	rm.currentRound = &Round{
+		Number:      api.NewBigInt(big.NewInt(1)),
+		StartTime:   time.Now(),
+		State:       RoundStateFinalizing,
+		Commitments: []*models.CertificationRequest{oldCommitment},
+		Snapshot:    nil,
+		// A normally finalized round has historical Commitments left for
+		// diagnostics, but no unresolved snapshot or pending commitments.
+		PendingCommitments: nil,
+	}
+
+	newCommitment := testutil.CreateTestCertificationRequest(t, "precollected_round_pending_marker")
+	newLeaf, err := commitmentLeafInput(newCommitment)
+	require.NoError(t, err)
+	newSnapshot, err := rm.smtBackend.CreateSnapshot(ctx)
+	require.NoError(t, err)
+	result, err := newSnapshot.AddLeavesClassified(ctx, []smtbackend.LeafInput{newLeaf})
+	require.NoError(t, err)
+	require.NoError(t, result.ValidateAllAccepted(1))
+	rm.markProofsPending([]*models.CertificationRequest{newCommitment})
+
+	require.NoError(t, rm.StartNewRoundWithSnapshot(
+		ctx,
+		api.NewBigInt(big.NewInt(2)),
+		newSnapshot,
+		[]*models.CertificationRequest{newCommitment},
+		[]smtbackend.LeafInput{newLeaf},
+		false,
+		"",
+	))
+
+	require.Zero(t, resetQueue.resetCount)
+	_, pending := rm.proofPending[newCommitment.StateID.String()]
+	require.True(t, pending)
 }
 
 func TestStaleCertificationRequestAbandonsStoredDurableProposal(t *testing.T) {

--- a/internal/storage/mongodb/connection.go
+++ b/internal/storage/mongodb/connection.go
@@ -234,6 +234,16 @@ func isPrimaryTransitionError(err error) bool {
 	}
 }
 
+func hasMongoErrorLabel(err error, label string) bool {
+	var labeledErr mongo.LabeledError
+	return errors.As(err, &labeledErr) && labeledErr.HasErrorLabel(label)
+}
+
+func isMongoMaxTimeMSExpiredError(err error) bool {
+	var cmdErr mongo.CommandError
+	return errors.As(err, &cmdErr) && cmdErr.IsMaxTimeMSExpiredError()
+}
+
 // CommitmentQueue returns the commitment queue implementation
 func (s *Storage) CommitmentQueue() interfaces.CommitmentQueue {
 	return s.commitmentStorage
@@ -322,12 +332,12 @@ func (s *Storage) WithTransaction(ctx context.Context, fn func(context.Context) 
 			// Abort the transaction on error
 			_ = session.AbortTransaction(ctx)
 
-			// Check if this is a transient error that we should retry
-			if cmdErr, ok := err.(mongo.CommandError); ok {
-				if cmdErr.HasErrorLabel(labelTransientTransaction) && attempt < maxRetries {
-					lastErr = err
-					continue // Retry
-				}
+			// Check if this is a transient error that we should retry.
+			// Storage methods wrap driver errors with %w for context, so use
+			// errors.As instead of a direct type assertion.
+			if hasMongoErrorLabel(err, labelTransientTransaction) && attempt < maxRetries {
+				lastErr = err
+				continue // Retry
 			}
 			// Non-transient error or max retries reached
 			return fmt.Errorf("transaction failed (attempt %d/%d): %w", attempt, maxRetries, err)
@@ -340,19 +350,16 @@ func (s *Storage) WithTransaction(ctx context.Context, fn func(context.Context) 
 				return nil // Success
 			}
 
-			cmdErr, ok := err.(mongo.CommandError)
-			if !ok {
-				return fmt.Errorf("transaction commit failed (attempt %d/%d): %w", attempt, maxRetries, err)
-			}
-
 			// TransientTransactionError on commit - retry whole transaction
-			if cmdErr.HasErrorLabel(labelTransientTransaction) && attempt < maxRetries {
+			if hasMongoErrorLabel(err, labelTransientTransaction) && attempt < maxRetries {
 				lastErr = err
 				break // Break inner loop, continue outer loop to retry whole transaction
 			}
 
 			// UnknownTransactionCommitResult - retry just the commit
-			if cmdErr.HasErrorLabel(labelUnknownTransactionCommit) && commitAttempt < maxRetries {
+			if hasMongoErrorLabel(err, labelUnknownTransactionCommit) &&
+				!isMongoMaxTimeMSExpiredError(err) &&
+				commitAttempt < maxRetries {
 				lastErr = err
 				continue // Retry commit
 			}

--- a/internal/storage/mongodb/connection.go
+++ b/internal/storage/mongodb/connection.go
@@ -306,10 +306,10 @@ const (
 	labelUnknownTransactionCommit = "UnknownTransactionCommitResult"
 )
 
-// WithTransaction executes a function within a MongoDB transaction with limited retries.
-// Only retries on transient errors (TransientTransactionError label).
+// WithTransaction executes a function within a MongoDB transaction with limited attempts.
+// Transient errors retry the transaction; unknown commit results retry only the commit.
 func (s *Storage) WithTransaction(ctx context.Context, fn func(context.Context) error) error {
-	const maxRetries = 3
+	const maxAttempts = 3
 
 	session, err := s.client.StartSession()
 	if err != nil {
@@ -318,7 +318,7 @@ func (s *Storage) WithTransaction(ctx context.Context, fn func(context.Context) 
 	defer session.EndSession(ctx)
 
 	var lastErr error
-	for attempt := 1; attempt <= maxRetries; attempt++ {
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		err = session.StartTransaction()
 		if err != nil {
 			return fmt.Errorf("failed to start transaction: %w", err)
@@ -335,23 +335,23 @@ func (s *Storage) WithTransaction(ctx context.Context, fn func(context.Context) 
 			// Check if this is a transient error that we should retry.
 			// Storage methods wrap driver errors with %w for context, so use
 			// errors.As instead of a direct type assertion.
-			if hasMongoErrorLabel(err, labelTransientTransaction) && attempt < maxRetries {
+			if hasMongoErrorLabel(err, labelTransientTransaction) && attempt < maxAttempts {
 				lastErr = err
 				continue // Retry
 			}
-			// Non-transient error or max retries reached
-			return fmt.Errorf("transaction failed (attempt %d/%d): %w", attempt, maxRetries, err)
+			// Non-transient error or final attempt reached.
+			return fmt.Errorf("transaction failed (attempt %d/%d): %w", attempt, maxAttempts, err)
 		}
 
 		// Try to commit with retry for unknown commit result
-		for commitAttempt := 1; commitAttempt <= maxRetries; commitAttempt++ {
+		for commitAttempt := 1; commitAttempt <= maxAttempts; commitAttempt++ {
 			err = session.CommitTransaction(ctx)
 			if err == nil {
 				return nil // Success
 			}
 
 			// TransientTransactionError on commit - retry whole transaction
-			if hasMongoErrorLabel(err, labelTransientTransaction) && attempt < maxRetries {
+			if hasMongoErrorLabel(err, labelTransientTransaction) && attempt < maxAttempts {
 				lastErr = err
 				break // Break inner loop, continue outer loop to retry whole transaction
 			}
@@ -359,26 +359,20 @@ func (s *Storage) WithTransaction(ctx context.Context, fn func(context.Context) 
 			// UnknownTransactionCommitResult - retry just the commit
 			if hasMongoErrorLabel(err, labelUnknownTransactionCommit) &&
 				!isMongoMaxTimeMSExpiredError(err) &&
-				commitAttempt < maxRetries {
+				commitAttempt < maxAttempts {
 				lastErr = err
 				continue // Retry commit
 			}
 
 			return fmt.Errorf("transaction commit failed (attempt %d/%d, commit %d/%d): %w",
-				attempt, maxRetries, commitAttempt, maxRetries, err)
+				attempt, maxAttempts, commitAttempt, maxAttempts, err)
 		}
 
-		// If we broke out of commit loop due to transient error, continue to retry whole transaction
-		if lastErr != nil {
-			continue
-		}
-
-		// Success
-		return nil
+		// The commit loop reaches here only for a transient error that requires
+		// retrying the whole transaction.
 	}
 
-	// Should not reach here, but just in case
-	return fmt.Errorf("transaction failed after %d retries: %w", maxRetries, lastErr)
+	return fmt.Errorf("transaction failed after %d attempts: %w", maxAttempts, lastErr)
 }
 
 // createIndexes creates all necessary database indexes

--- a/internal/storage/mongodb/connection_test.go
+++ b/internal/storage/mongodb/connection_test.go
@@ -39,6 +39,29 @@ func TestIsPrimaryTransitionError(t *testing.T) {
 	require.False(t, isPrimaryTransitionError(errors.New("plain error")))
 }
 
+func TestHasMongoErrorLabelMatchesWrappedLabeledErrors(t *testing.T) {
+	labeledErrors := []error{
+		mongo.CommandError{
+			Message: "WriteConflict",
+			Labels:  []string{labelTransientTransaction},
+		},
+		mongo.WriteException{
+			Labels: []string{labelTransientTransaction},
+		},
+		mongo.BulkWriteException{
+			Labels: []string{labelTransientTransaction},
+		},
+	}
+
+	for _, err := range labeledErrors {
+		wrapped := fmt.Errorf("failed to delete aggregator records by block and proposal: %w", err)
+		require.True(t, hasMongoErrorLabel(wrapped, labelTransientTransaction))
+		require.False(t, hasMongoErrorLabel(wrapped, labelUnknownTransactionCommit))
+	}
+
+	require.False(t, hasMongoErrorLabel(errors.New("plain error"), labelTransientTransaction))
+}
+
 func TestMongoWriteConcern(t *testing.T) {
 	t.Run("default majority journaled", func(t *testing.T) {
 		wc := mongoWriteConcern(config.DatabaseConfig{})
@@ -264,6 +287,7 @@ func TestWithTransaction_TransientError_Retries(t *testing.T) {
 				_, err := coll.UpdateOne(txCtx, bson.M{"_id": "conflict"}, bson.M{"$inc": bson.M{"value": 10}})
 				if err != nil {
 					firstAttemptFailed <- err
+					return fmt.Errorf("failed to delete aggregator records by block and proposal: %w", err)
 				}
 				return err
 			}

--- a/internal/storage/mongodb/connection_test.go
+++ b/internal/storage/mongodb/connection_test.go
@@ -62,6 +62,18 @@ func TestHasMongoErrorLabelMatchesWrappedLabeledErrors(t *testing.T) {
 	require.False(t, hasMongoErrorLabel(errors.New("plain error"), labelTransientTransaction))
 }
 
+func TestIsMongoMaxTimeMSExpiredErrorMatchesWrappedCommandError(t *testing.T) {
+	err := fmt.Errorf("commit failed: %w", mongo.CommandError{
+		Code:   50,
+		Name:   "MaxTimeMSExpired",
+		Labels: []string{labelUnknownTransactionCommit},
+	})
+
+	require.True(t, isMongoMaxTimeMSExpiredError(err))
+	require.False(t, isMongoMaxTimeMSExpiredError(mongo.CommandError{Code: 51}))
+	require.False(t, isMongoMaxTimeMSExpiredError(errors.New("plain error")))
+}
+
 func TestMongoWriteConcern(t *testing.T) {
 	t.Run("default majority journaled", func(t *testing.T) {
 		wc := mongoWriteConcern(config.DatabaseConfig{})

--- a/internal/storage/redis/commitment.go
+++ b/internal/storage/redis/commitment.go
@@ -74,7 +74,9 @@ type CommitmentStorage struct {
 	// Restart recovery: on startup, exhaust all pending messages before reading new ones
 	// This ensures messages stuck in "pending" state (from crashed consumer) are recovered
 	// Once all pending are read, switch to new messages permanently
-	pendingExhausted atomic.Bool
+	pendingExhausted       atomic.Bool
+	pendingSweepMu         sync.Mutex
+	pendingSweepGeneration uint64
 
 	// Batching channels
 	pendingChan chan *pendingCommitment
@@ -106,6 +108,9 @@ func NewCommitmentStorage(client *redis.Client, streamName string, serverID stri
 // ResetPendingSweep re-enables the pending-entry sweep. A running streamer will
 // notice this before its next new-message read and reclaim entries left unacked.
 func (cs *CommitmentStorage) ResetPendingSweep() {
+	cs.pendingSweepMu.Lock()
+	defer cs.pendingSweepMu.Unlock()
+	cs.pendingSweepGeneration++
 	cs.pendingExhausted.Store(false)
 }
 
@@ -887,6 +892,10 @@ func (cs *CommitmentStorage) StreamCertificationRequests(ctx context.Context, co
 // and pushes each pending entry to commitmentChan exactly once, then sets
 // pendingExhausted so the caller switches to new-messages mode.
 func (cs *CommitmentStorage) drainPendingForConsumer(ctx context.Context, commitmentChan chan<- *models.CertificationRequest) error {
+	cs.pendingSweepMu.Lock()
+	sweepGeneration := cs.pendingSweepGeneration
+	cs.pendingSweepMu.Unlock()
+
 	nextPendingID := "0"
 	for {
 		select {
@@ -942,6 +951,10 @@ func (cs *CommitmentStorage) drainPendingForConsumer(ctx context.Context, commit
 		}
 	}
 
-	cs.pendingExhausted.Store(true)
+	cs.pendingSweepMu.Lock()
+	if cs.pendingSweepGeneration == sweepGeneration {
+		cs.pendingExhausted.Store(true)
+	}
+	cs.pendingSweepMu.Unlock()
 	return nil
 }

--- a/internal/storage/redis/commitment_integration_test.go
+++ b/internal/storage/redis/commitment_integration_test.go
@@ -1068,6 +1068,61 @@ CollectSecond:
 	}
 }
 
+func (suite *RedisTestSuite) TestPendingExhausted_ResetDuringActiveSweepIsNotLost() {
+	ctx := suite.ctx
+	t := suite.T()
+
+	commitments := []*models.CertificationRequest{
+		createTestCommitment(),
+		createTestCommitment(),
+		createTestCommitment(),
+	}
+	require.NoError(t, suite.storage.StoreBatch(ctx, commitments))
+
+	// Deliver the entries once so they are all in this consumer's PEL.
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	streamCh := make(chan *models.CertificationRequest, len(commitments))
+	streamDone := make(chan struct{})
+	go func() {
+		_ = suite.storage.StreamCertificationRequests(streamCtx, streamCh)
+		close(streamDone)
+	}()
+	require.Eventually(t, func() bool {
+		return len(streamCh) == len(commitments)
+	}, 2*time.Second, 25*time.Millisecond)
+	cancelStream()
+	<-streamDone
+
+	suite.storage.ResetPendingSweep()
+	firstDrainCh := make(chan *models.CertificationRequest, 1)
+	firstDrainDone := make(chan error, 1)
+	go func() {
+		firstDrainDone <- suite.storage.drainPendingForConsumer(ctx, firstDrainCh)
+	}()
+
+	// The one-slot channel blocks the active sweep after its first delivery.
+	require.Eventually(t, func() bool {
+		return len(firstDrainCh) == 1
+	}, 2*time.Second, 25*time.Millisecond)
+	suite.storage.ResetPendingSweep()
+
+	for range commitments {
+		select {
+		case <-firstDrainCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out draining first replay sweep")
+		}
+	}
+	require.NoError(t, <-firstDrainDone)
+	require.False(t, suite.storage.pendingExhausted.Load(),
+		"a reset requested during a sweep must remain visible after that sweep finishes")
+
+	secondDrainCh := make(chan *models.CertificationRequest, len(commitments))
+	require.NoError(t, suite.storage.drainPendingForConsumer(ctx, secondDrainCh))
+	require.Len(t, secondDrainCh, len(commitments))
+	require.True(t, suite.storage.pendingExhausted.Load())
+}
+
 // TestPendingExhausted_ResetAfterDiscardingLocalBuffer covers the precollector
 // discard path: entries already delivered into the local channel are stale when
 // Redis PEL is about to become the replay source again.


### PR DESCRIPTION
## Summary

  - Harden BFT client startup, shutdown, HA deactivation, and durable-proposal recovery.
  - Clear superseded round state while preserving unrelated proof-pending markers.
  - Reset Redis pending sweeps for unresolved rounds and prevent resets from being lost during an active sweep.
  - Detect wrapped MongoDB transaction labels and correctly retry transient transaction and commit failures.

  Includes regression, race, storage integration, and BFT lifecycle coverage.